### PR TITLE
Support embedded jpeg thumbs + fix debug modes

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -88,7 +88,26 @@ media:
       # width
       # height: Predefined thumbnail dimensions used to pick the most
       #         appropriately-sized thumbnail for the zoom level. 
+      # 
+      # extra_cost: Additional weight to add when picking the closest thumbnail.
+      #             Higher number means that other thumbnails will be preferred
+      #             if they exist.
+
+      #
+      # Embedded JPEG thumbnail
+      #
+      - name: exif-thumb
+        exif: ThumbnailImage
+        fit: INSIDE
+        width: 120
+        height: 120
+        # It's expensive to extract, so this makes it more of a last resort, but
+        # still a lot better than loading the original photo.
+        extra_cost: 10
         
+      #
+      # Synology Moments / Photo Station thumbnails
+      #
       - name: S
         path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_S.jpg"
         fit: INSIDE
@@ -122,6 +141,9 @@ media:
   videos:
     extensions: [".mp4"]
     thumbnails:
+      #
+      # Synology Moments / Photo Station video variants
+      #
       - name: M
         path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_FILM_M.mp4"
         fit: OUTSIDE

--- a/internal/image/cache.go
+++ b/internal/image/cache.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"photofield/internal/metrics"
 	"reflect"
+	"time"
 	"unsafe"
 
 	"github.com/dgraph-io/ristretto"
@@ -47,7 +48,16 @@ func newInfoCache() InfoCache {
 	}
 }
 
-func newImageCache(caches Caches) *ristretto.Cache {
+type ImageCache struct {
+	cache *ristretto.Cache
+}
+
+type ImageLoader interface {
+	Acquire(key string, path string, thumbnail *Thumbnail) (image.Image, Info, error)
+	Release(key string)
+}
+
+func newImageCache(caches Caches) ImageCache {
 	cache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1e6,                         // number of keys to track frequency of
 		MaxCost:     caches.Image.MaxSizeBytes(), // maximum cost of cache
@@ -59,7 +69,7 @@ func newImageCache(caches Caches) *ristretto.Cache {
 			if img == nil {
 				return 1
 			}
-			switch img := (*img).(type) {
+			switch img := img.(type) {
 
 			case *image.YCbCr:
 				return int64(unsafe.Sizeof(*img)) +
@@ -95,7 +105,39 @@ func newImageCache(caches Caches) *ristretto.Cache {
 		panic(err)
 	}
 	metrics.AddRistretto("image_cache", cache)
-	return cache
+	return ImageCache{
+		cache: cache,
+	}
+}
+
+func (c *ImageCache) GetOrLoad(path string, thumbnail *Thumbnail, loader ImageLoader) (image.Image, Info, error) {
+	tries := 10
+	key := path
+	if thumbnail != nil {
+		key += "|thumbnail|" + thumbnail.Name
+	}
+	for try := 0; try < tries; try++ {
+		value, found := c.cache.Get(key)
+		if found {
+			imageRef := value.(imageRef)
+			return imageRef.image, imageRef.info, imageRef.err
+		} else {
+			image, info, err := loader.Acquire(key, path, thumbnail)
+			imageRef := imageRef{
+				image: image,
+				info:  info,
+				err:   err,
+			}
+			c.cache.SetWithTTL(key, imageRef, 0, 10*time.Minute)
+			loader.Release(key)
+			return image, info, err
+		}
+	}
+	return nil, Info{}, fmt.Errorf("unable to get image after %v tries", tries)
+}
+
+func (c *ImageCache) Delete(path string) {
+	c.cache.Del(path)
 }
 
 func newFileExistsCache() *ristretto.Cache {

--- a/internal/image/info.go
+++ b/internal/image/info.go
@@ -59,6 +59,7 @@ func (info *Info) SetColorRGB32(r uint32, g uint32, b uint32) {
 
 type Orientation int8
 
+// All rotations are counter-clockwise
 const (
 	Normal                    Orientation = 1
 	MirrorHorizontal          Orientation = 2

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -67,7 +67,7 @@ type Source struct {
 	database *Database
 
 	imageInfoCache  InfoCache
-	imageCache      *ristretto.Cache
+	imageCache      ImageCache
 	fileExistsCache *ristretto.Cache
 
 	pathToIndex sync.Map

--- a/internal/render/bitmap.go
+++ b/internal/render/bitmap.go
@@ -24,24 +24,63 @@ type Bitmap struct {
 
 func (bitmap *Bitmap) Draw(rimg draw.Image, c *canvas.Context, scales Scales, source *image.Source) error {
 	if bitmap.Sprite.IsVisible(c, scales) {
-		image, err := source.GetImage(bitmap.Path)
+		image, _, err := source.GetImage(bitmap.Path)
 		if err != nil {
 			return err
 		}
 
-		model := bitmap.Sprite.Rect.GetMatrixFitImageRotate(image, bitmap.Orientation)
-		m := c.View().Mul(model)
-
-		renderImageFast(rimg, *image, m)
+		bitmap.DrawImage(rimg, image, c)
 	}
 	return nil
 }
 
+func (bitmap *Bitmap) DrawImage(rimg draw.Image, img goimage.Image, c *canvas.Context) {
+	bounds := img.Bounds()
+	model := bitmap.Sprite.Rect.GetMatrixFitBoundsRotate(bounds, bitmap.Orientation)
+	// modelTopLeft := model.Dot(canvas.Point{X: 0, Y: 0})
+	// modelBottomRight := model.Dot(canvas.Point{X: float64(bounds.Max.X), Y: float64(bounds.Max.Y)})
+	m := c.View().Mul(model)
+	renderImageFast(rimg, img, m)
+	// renderImageFastCropped(rimg, img, m, bitmap.Sprite.Rect, modelTopLeft, modelBottomRight)
+}
+
 func renderImageFast(rimg draw.Image, img goimage.Image, m canvas.Matrix) {
-	origin := m.Dot(canvas.Point{X: 0, Y: float64(img.Bounds().Size().Y)})
+	bounds := img.Bounds()
+	origin := m.Dot(canvas.Point{X: 0, Y: float64(bounds.Size().Y)})
 	h := float64(rimg.Bounds().Size().Y)
-	aff3 := f64.Aff3{m[0][0], -m[0][1], origin.X, -m[1][0], m[1][1], h - origin.Y}
-	draw.ApproxBiLinear.Transform(rimg, aff3, img, img.Bounds(), draw.Src, nil)
+	aff3 := f64.Aff3{
+		m[0][0], -m[0][1], origin.X,
+		-m[1][0], m[1][1], h - origin.Y,
+	}
+	draw.ApproxBiLinear.Transform(rimg, aff3, img, bounds, draw.Src, nil)
+}
+
+// TODO finish implementation
+func renderImageFastCropped(rimg draw.Image, img goimage.Image, m canvas.Matrix, crop Rect, modelTopLeft canvas.Point, modelBottomRight canvas.Point) {
+	bounds := img.Bounds()
+	// bounds := goimage.Rect(0, 0, int(modelBounds.X), int(modelBounds.Y))
+	origin := m.Dot(canvas.Point{X: 0, Y: float64(bounds.Size().Y)})
+	h := float64(rimg.Bounds().Size().Y)
+	aff3 := f64.Aff3{
+		m[0][0], -m[0][1], origin.X,
+		-m[1][0], m[1][1], h - origin.Y,
+	}
+	// croptl := m.Dot(canvas.Point{crop.X, crop.Y})
+	// cropbr := m.Dot(canvas.Point{crop.X + crop.W, crop.Y + crop.H})
+	// println(bounds.String(), crop.String(), croptl.String(), cropbr.String())
+	// tx, ty := m.D
+
+	model := Rect{
+		X: modelTopLeft.X,
+		Y: modelTopLeft.Y,
+		W: modelBottomRight.X - modelTopLeft.X,
+		H: modelBottomRight.Y - modelTopLeft.Y,
+	}
+
+	println(bounds.String(), "crop", crop.String(), "model", model.String())
+	// bounds = bounds.Inset(10)
+	// bounds =
+	draw.ApproxBiLinear.Transform(rimg, aff3, img, bounds, draw.Src, nil)
 }
 
 func (bitmap *Bitmap) GetSize(source *image.Source) image.Size {
@@ -49,16 +88,15 @@ func (bitmap *Bitmap) GetSize(source *image.Source) image.Size {
 	return image.Size{X: info.Width, Y: info.Height}
 }
 
-func (bitmap *Bitmap) DrawOverdraw(c *canvas.Context, source *image.Source) {
+func (bitmap *Bitmap) DrawOverdraw(c *canvas.Context, size goimage.Point) {
 	style := c.Style
 
-	size := bitmap.GetSize(source)
 	pixelZoom := bitmap.Sprite.Rect.GetPixelZoom(c, size)
-	barWidth := -pixelZoom * 0.1
+	// barWidth := -pixelZoom * 0.1
 	// barHeight := 0.04
-	alpha := pixelZoom * 0.1 * 0xFF
+	alpha := pixelZoom * 0.025 * 0xFF
 	max := 0.8 * float64(0xFF)
-	if barWidth > 0 {
+	if alpha < 0 {
 		alpha = math.Min(max, math.Max(0, -alpha))
 		style.FillColor = getRGBA(color.NRGBA{0xFF, 0x00, 0x00, uint8(alpha)})
 	} else {

--- a/main.go
+++ b/main.go
@@ -947,7 +947,7 @@ func main() {
 		Main:   *fontFamily,
 		Header: fontFamily.Face(14.0, canvas.Lightgray, canvas.FontRegular, canvas.FontNormal),
 		Hour:   fontFamily.Face(24.0, canvas.Lightgray, canvas.FontRegular, canvas.FontNormal),
-		Debug:  fontFamily.Face(30.0, canvas.Black, canvas.FontRegular, canvas.FontNormal),
+		Debug:  fontFamily.Face(34.0, canvas.Black, canvas.FontRegular, canvas.FontNormal),
 	}
 	sceneSource.DefaultScene = defaultSceneConfig.Scene
 

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -84,6 +84,20 @@
             >
             </ui-icon-button>
           </div>
+          <expand-button
+            :expanded="settingsExtraExpanded"
+            @click="settingsExtraExpanded = !settingsExtraExpanded"
+          ></expand-button>
+          <template v-if="settingsExtraExpanded">
+            <ui-form-field>
+              <ui-checkbox v-model="settings.debug.overdraw"></ui-checkbox>
+              <label>Debug Overdraw</label>
+            </ui-form-field>
+            <ui-form-field>
+              <ui-checkbox v-model="settings.debug.thumbnails"></ui-checkbox>
+              <label>Debug Thumbnails</label>
+            </ui-form-field>
+          </template>
         </div>
         <ui-icon-button
           icon="settings"
@@ -198,6 +212,10 @@ export default {
           height: 100,
         },
         layout: "",
+        debug: {
+          overdraw: false,
+          thumbnails: false,
+        },
       },
       layoutOptions: [
         { label: "Album", value: "ALBUM" },
@@ -205,6 +223,7 @@ export default {
         { label: "Wall", value: "WALL" },
       ],
       settingsExpanded: false,
+      settingsExtraExpanded: false,
       tasksExpanded: false,
       collectionExpanded: false,
       load: {

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -68,13 +68,19 @@ export async function createTask(type, id) {
   });
 }
 
-export function getTileUrl(sceneId, level, x, y, tileSize) {
-  let url = `${host}/scenes/${sceneId}/tiles?${qs.stringify({
+export function getTileUrl(sceneId, level, x, y, tileSize, debug) {
+  const params = {
     tile_size: tileSize,
     zoom: level,
     x,
     y,
-  })}`;
+  };
+  for (const key in debug) {
+    if (Object.hasOwnProperty.call(debug, key)) {
+      if (debug[key]) params[`debug_${key}`] = debug[key];
+    }
+  }
+  let url = `${host}/scenes/${sceneId}/tiles?${qs.stringify(params)}`;
   return url;
 }
 

--- a/ui/src/components/NaturalViewer.vue
+++ b/ui/src/components/NaturalViewer.vue
@@ -21,6 +21,7 @@
       :interactive="!nativeScroll && !panDisabled"
       :scene="scene"
       :tileSize="tileSize"
+      :debug="settings.debug"
       @viewer="overlayViewer = $event"
       @zoom="onZoom"
       @view="onView"

--- a/ui/src/components/TileViewer.vue
+++ b/ui/src/components/TileViewer.vue
@@ -17,6 +17,7 @@ export default {
     tileSize: Number,
     view: Object,
     immediate: Boolean,
+    debug: Object,
   },
 
   emits: ["zoom", "click", "view", "reset", "load", "key-down", "viewer"],
@@ -53,6 +54,13 @@ export default {
 
     immediate() {
       this.reset();
+    },
+
+    debug: {
+      deep: true,
+      handler() {
+        this.reset();
+      },
     },
 
     interactive(interactive) {
@@ -324,7 +332,7 @@ export default {
         maxLevel,
         getTileUrl: (level, x, y) => {
           if (!this.scene) return;
-          return getTileUrl(this.scene.id, level, x, y, tileSize);
+          return getTileUrl(this.scene.id, level, x, y, tileSize, this.debug);
         }
       }
     },


### PR DESCRIPTION
# Embedded JPEG thumbnails

Embedded JPEG thumbnails are now supported. Extracting them is slower than loading pregenerated thumbnails already on disk, but way faster than loading the original, so it's a nice middle ground if you don't already have thumbnails.
![Photofield8](https://user-images.githubusercontent.com/1451391/144293168-173845cf-e0bd-4d95-ab80-ceca55e8b6ef.gif)

# Debug Modes

Additionally, the two debug modes supported by the API are now accessible again. They exist to more easily debug how and when the thumbnails are being used.

## Debug Overdraw

Shows how close to "perfect" is the thumbnail / image being loaded.
More red 👉 too high resolution / wasted loaded pixels / slow loading
More blue 👉 not enough resolution / blurry display

Using only embedded JPEG thumbnails shows that when the original images has to be used, it is way too high of a resolution for the currently displayed size, so it's slow.

https://user-images.githubusercontent.com/1451391/144292927-0e5e3d3b-84a0-4d36-bb83-7a8a8f7cd8d6.mp4

## Debug Thumbnails

Shows the resolution of the thumbnail / image being used, the "distance" from the ideal resolution for the currently displayed size and the name of the thumbnail (or `original` for the original photo).

https://user-images.githubusercontent.com/1451391/144292940-f298474f-2924-42b2-83a0-b5646b00d186.mp4


