### PR TITLE
Allow use of environment variable to specify a custom server address

### DIFF
--- a/main.go
+++ b/main.go
@@ -965,7 +965,10 @@ func main() {
 	// addExampleScene()
 	// renderSample(defaultSceneConfig.Config, sceneSource.GetScene(defaultSceneConfig, imageSource))
 
-	addr := ":8080"
+	addr, exists := os.LookupEnv("PHOTOFIELD_ADDRESS")
+	if !exists {
+		addr = ":8080"
+	}
 
 	apiPrefix, exists := os.LookupEnv("PHOTOFIELD_API_PREFIX")
 	if !exists {


### PR DESCRIPTION
The port of the address serving the gallery is hardcoded to 8080. I'm already running a service on this address which I could not change. I've added a optional environment variable setting to specify a custom server address.