### PR TITLE
Large collections

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -311,25 +311,10 @@ paths:
         "404":
           $ref: "#/components/responses/FileNotFound"
 
-  /files/{id}/image-variants/{size}/{filename}:
+  /files/{id}/variants/{size}/{filename}:
     get:
-      description: Get an image thumbnail of the specified predefined size and
-        with an arbitrary filename as part of the URL
-      tags: ["Files"]
-      parameters:
-        - $ref: "#/components/parameters/FileIdPathParam"
-        - $ref: "#/components/parameters/FilenamePathParam"
-        - $ref: "#/components/parameters/SizePathParam"
-      responses:
-        "200":
-          $ref: "#/components/responses/FileResponse"
-        "404":
-          $ref: "#/components/responses/FileNotFound"
-
-  /files/{id}/video-variants/{size}/{filename}:
-    get:
-      description: Get a resized video of the specified predefined size and
-        with an arbitrary filename as part of the URL
+      description: Get an image or resized video variant/thumbnail of the
+        specified predefined size and with an arbitrary filename as part of the URL
       tags: ["Files"]
       parameters:
         - $ref: "#/components/parameters/FileIdPathParam"

--- a/api.yaml
+++ b/api.yaml
@@ -462,6 +462,9 @@ components:
           type: integer
           minimum: 0
           example: 506
+        loading:
+          type: boolean
+          description: True while the scene is loading and the dimensions are not yet known.
 
     Collection:
       type: object

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -60,96 +60,104 @@ media:
     # Extensions to use to understand a file to be an image
     extensions: [".jpg", ".jpeg", ".png", ".gif"]
 
-    # Pre-generated thumbnail configuration, these thumbnails will be used to
-    # greatly speed up the rendering
-    thumbnails:
-  
-      # name: Short thumbnail type name
-      #
-      # path: Path template where to find the thumbnail.
-      #   {{.Dir}} is replaced by the parent directory of the original photo
-      #   {{.Filename}} is replaced by the original photo filename
-      #
-      # fit: Aspect ratio fit of the thumbnail in case it doesn't match the
-      #      original photo.
-      #
-      #   INSIDE
-      #     The thumbnail size is the maximum size of each dimension, so in case
-      #     of different aspect ratios, one dimension will always be smaller.
-      #
-      #   OUTSIDE
-      #     The thumbnail size is the minimum size of each dimension, so in case
-      #     of different aspect ratios, one dimension will always be bigger.
-      #
-      #   ORIGINAL
-      #     The size of the thumbnail is equal the size of the original. Mostly
-      #     useful for transcoded or differently encoded files.
-      #
-      # width
-      # height: Predefined thumbnail dimensions used to pick the most
-      #         appropriately-sized thumbnail for the zoom level. 
-      # 
-      # extra_cost: Additional weight to add when picking the closest thumbnail.
-      #             Higher number means that other thumbnails will be preferred
-      #             if they exist.
-
-      #
-      # Embedded JPEG thumbnail
-      #
-      - name: exif-thumb
-        exif: ThumbnailImage
-        fit: INSIDE
-        width: 120
-        height: 120
-        # It's expensive to extract, so this makes it more of a last resort, but
-        # still a lot better than loading the original photo.
-        extra_cost: 10
-        
-      #
-      # Synology Moments / Photo Station thumbnails
-      #
-      - name: S
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_S.jpg"
-        fit: INSIDE
-        width: 120
-        height: 120
-        
-      - name: SM
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_SM.jpg"
-        fit: OUTSIDE
-        width: 240
-        height: 240
-        
-      - name: M
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_M.jpg"
-        fit: OUTSIDE
-        width: 320
-        height: 320
-        
-      - name: B
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_B.jpg"
-        fit: INSIDE
-        width: 640
-        height: 640
-        
-      - name: XL
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_XL.jpg"
-        fit: OUTSIDE
-        width: 1280
-        height: 1280
-  
   videos:
     extensions: [".mp4"]
-    thumbnails:
-      #
-      # Synology Moments / Photo Station video variants
-      #
-      - name: M
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_FILM_M.mp4"
-        fit: OUTSIDE
-        width: 720
-        height: 720
-        
-      - name: H264
-        path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_FILM_H264.mp4"
-        fit: ORIGINAL
+
+  # Pre-generated thumbnail configuration, these thumbnails will be used to
+  # greatly speed up the rendering
+  thumbnails:
+
+    # name: Short thumbnail type name
+    #
+    # path: Path template where to find the thumbnail.
+    #   {{.Dir}} is replaced by the parent directory of the original photo
+    #   {{.Filename}} is replaced by the original photo filename
+    #
+    # fit: Aspect ratio fit of the thumbnail in case it doesn't match the
+    #      original photo.
+    #
+    #   INSIDE
+    #     The thumbnail size is the maximum size of each dimension, so in case
+    #     of different aspect ratios, one dimension will always be smaller.
+    #
+    #   OUTSIDE
+    #     The thumbnail size is the minimum size of each dimension, so in case
+    #     of different aspect ratios, one dimension will always be bigger.
+    #
+    #   ORIGINAL
+    #     The size of the thumbnail is equal the size of the original. Mostly
+    #     useful for transcoded or differently encoded files.
+    #
+    # width
+    # height: Predefined thumbnail dimensions used to pick the most
+    #         appropriately-sized thumbnail for the zoom level. 
+    # 
+    # extra_cost: Additional weight to add when picking the closest thumbnail.
+    #             Higher number means that other thumbnails will be preferred
+    #             if they exist.
+
+    #
+    # Embedded JPEG thumbnail
+    #
+    - name: exif-thumb
+      exif: ThumbnailImage
+      extensions: [".jpg", ".jpeg"]
+      fit: INSIDE
+      width: 120
+      height: 120
+      # It's expensive to extract, so this makes it more of a last resort, but
+      # still a lot better than loading the original photo.
+      extra_cost: 10
+      
+    #
+    # Synology Moments / Photo Station thumbnails
+    #
+    - name: S
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_S.jpg"
+      extensions: [".jpg", ".jpeg", ".png", ".gif", ".mp4"]
+      fit: INSIDE
+      width: 120
+      height: 120
+      
+    - name: SM
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_SM.jpg"
+      extensions: [".jpg", ".jpeg", ".png", ".gif", ".mp4"]
+      fit: OUTSIDE
+      width: 240
+      height: 240
+      
+    - name: M
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_M.jpg"
+      extensions: [".jpg", ".jpeg", ".png", ".gif", ".mp4"]
+      fit: OUTSIDE
+      width: 320
+      height: 320
+      
+    - name: B
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_B.jpg"
+      extensions: [".jpg", ".jpeg", ".png", ".gif"]
+      fit: INSIDE
+      width: 640
+      height: 640
+      
+    - name: XL
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_THUMB_XL.jpg"
+      extensions: [".jpg", ".jpeg", ".png", ".gif", ".mp4"]
+      fit: OUTSIDE
+      width: 1280
+      height: 1280
+      
+    #
+    # Synology Moments / Photo Station video variants
+    #
+    - name: FM
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_FILM_M.mp4"
+      extensions: [".mp4"]
+      fit: OUTSIDE
+      width: 720
+      height: 720
+      
+    - name: H264
+      path: "{{.Dir}}@eaDir/{{.Filename}}/SYNOPHOTO_FILM_H264.mp4"
+      extensions: [".mp4"]
+      fit: ORIGINAL

--- a/internal/image/database.go
+++ b/internal/image/database.go
@@ -374,7 +374,7 @@ func (source *Database) GetPathFromId(id ImageId) (string, bool) {
 		FROM infos
 		JOIN prefix ON path_prefix_id == prefix.id
 		WHERE infos.rowid == ?;`)
-	defer stmt.Finalize()
+	defer stmt.Reset()
 
 	stmt.BindInt64(1, (int64)(id))
 
@@ -395,7 +395,7 @@ func (source *Database) Get(id ImageId) (InfoResult, bool) {
 		SELECT width, height, orientation, color, created_at
 		FROM infos
 		WHERE rowid == ?;`)
-	defer stmt.Finalize()
+	defer stmt.Reset()
 
 	stmt.BindInt64(1, (int64)(id))
 
@@ -430,7 +430,7 @@ func (source *Database) GetDir(dir string) (InfoResult, bool) {
 	stmt := conn.Prep(`
 		SELECT indexed_at FROM dirs
 		WHERE path = ?;`)
-	defer stmt.Finalize()
+	defer stmt.Reset()
 
 	stmt.BindText(1, dir)
 
@@ -479,7 +479,7 @@ func (source *Database) SetIndexed(dir string) {
 }
 
 func (source *Database) List(dirs []string, options ListOptions) <-chan InfoListResult {
-	out := make(chan InfoListResult, 10000)
+	out := make(chan InfoListResult, 1000)
 	go func() {
 		defer metrics.Elapsed("listing infos sqlite")()
 
@@ -523,7 +523,7 @@ func (source *Database) List(dirs []string, options ListOptions) <-chan InfoList
 
 		stmt := conn.Prep(sql)
 		bindIndex := 1
-		defer stmt.Finalize()
+		defer stmt.Reset()
 
 		for _, dir := range dirs {
 			stmt.BindText(bindIndex, dir+"%")
@@ -604,7 +604,7 @@ func (source *Database) ListPaths(dirs []string, limit int) <-chan string {
 
 		stmt := conn.Prep(sql)
 		bindIndex := 1
-		defer stmt.Finalize()
+		defer stmt.Reset()
 
 		for _, dir := range dirs {
 			stmt.BindText(bindIndex, dir+"%")
@@ -665,7 +665,7 @@ func (source *Database) ListIds(dirs []string, limit int) <-chan ImageId {
 
 		stmt := conn.Prep(sql)
 		bindIndex := 1
-		defer stmt.Finalize()
+		defer stmt.Reset()
 
 		for _, dir := range dirs {
 			stmt.BindText(bindIndex, dir+"%")

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -115,20 +115,9 @@ func (source *Source) GetImageOrThumbnail(path string, thumbnail *Thumbnail) (im
 	return source.imageCache.GetOrLoad(path, thumbnail, source)
 }
 
-func (source *Source) GetSmallestThumbnail(path string) string {
-	for i := range source.Images.Thumbnails {
-		thumbnail := &source.Images.Thumbnails[i]
-		thumbnailPath := thumbnail.GetPath(path)
-		if source.Exists(thumbnailPath) {
-			return thumbnailPath
-		}
-	}
-	return ""
-}
-
 func (source *Source) LoadSmallestImage(path string) (image.Image, error) {
-	for i := range source.Images.Thumbnails {
-		thumbnail := &source.Images.Thumbnails[i]
+	for i := range source.Thumbnails {
+		thumbnail := &source.Thumbnails[i]
 		thumbnailPath := thumbnail.GetPath(path)
 		file, err := os.Open(thumbnailPath)
 		if err != nil {

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -47,17 +47,17 @@ type Config struct {
 	ConcurrentMetaLoads  int  `json:"concurrent_meta_loads"`
 	ConcurrentColorLoads int  `json:"concurrent_color_loads"`
 
-	ListExtensions []string   `json:"extensions"`
-	DateFormats    []string   `json:"date_formats"`
-	Images         FileConfig `json:"images"`
-	Videos         FileConfig `json:"videos"`
+	ListExtensions []string    `json:"extensions"`
+	DateFormats    []string    `json:"date_formats"`
+	Images         FileConfig  `json:"images"`
+	Videos         FileConfig  `json:"videos"`
+	Thumbnails     []Thumbnail `json:"thumbnails"`
 
 	Caches Caches `json:"caches"`
 }
 
 type FileConfig struct {
-	Extensions []string    `json:"extensions"`
-	Thumbnails []Thumbnail `json:"thumbnails"`
+	Extensions []string `json:"extensions"`
 }
 
 type Source struct {
@@ -209,4 +209,22 @@ func (source *Source) GetDir(dir string) Info {
 	dir = filepath.FromSlash(dir)
 	result, _ := source.database.GetDir(dir)
 	return result.Info
+}
+
+func (source *Source) GetApplicableThumbnails(path string) []Thumbnail {
+	thumbs := make([]Thumbnail, 0, len(source.Thumbnails))
+	pathExt := strings.ToLower(filepath.Ext(path))
+	for _, t := range source.Thumbnails {
+		supported := false
+		for _, ext := range t.Extensions {
+			if pathExt == ext {
+				supported = true
+				break
+			}
+		}
+		if supported {
+			thumbs = append(thumbs, t)
+		}
+	}
+	return thumbs
 }

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -161,7 +161,7 @@ func (source *Source) ListInfos(dirs []string, options ListOptions) <-chan Sourc
 	for i := range dirs {
 		dirs[i] = filepath.FromSlash(dirs[i])
 	}
-	out := make(chan SourcedInfo, 10000)
+	out := make(chan SourcedInfo, 1000)
 	go func() {
 		infos := source.database.List(dirs, options)
 		for info := range infos {

--- a/internal/image/thumbnail.go
+++ b/internal/image/thumbnail.go
@@ -17,8 +17,8 @@ type Thumbnail struct {
 	Name            string `json:"name"`
 	PathTemplateRaw string `json:"path"`
 	PathTemplate    *template.Template
-
-	Exif string `json:"exif"`
+	Exif            string   `json:"exif"`
+	Extensions      []string `json:"extensions"`
 
 	SizeTypeRaw string `json:"fit"`
 	SizeType    ThumbnailSizeType

--- a/internal/layout/album.go
+++ b/internal/layout/album.go
@@ -140,6 +140,7 @@ func LayoutAlbum(layout Layout, collection collection.Collection, scene *render.
 
 		layoutCounter.Set(index)
 		index++
+		scene.FileCount = index
 	}
 	layoutPlaced()
 

--- a/internal/layout/album.go
+++ b/internal/layout/album.go
@@ -61,8 +61,7 @@ func LayoutAlbumEvent(layout Layout, rect render.Rect, event *AlbumEvent, scene 
 	scene.Texts = append(scene.Texts, text)
 	rect.Y += text.Sprite.Rect.H + 10
 
-	photos := addSectionPhotos(&event.Section, scene, source)
-	newBounds := layoutSectionPhotos(photos, rect, layout, scene, source)
+	newBounds := addSectionToScene(&event.Section, scene, rect, layout, source)
 
 	rect.Y = newBounds.Y + newBounds.H
 	if event.LastOnDay {
@@ -132,6 +131,9 @@ func LayoutAlbum(layout Layout, collection collection.Collection, scene *render.
 				StartTime:  photoTime,
 				FirstOnDay: !SameDay(lastPhotoTime, photoTime),
 				Elapsed:    elapsed,
+				Section: Section{
+					infos: event.Section.infos[:0],
+				},
 			}
 		}
 		lastPhotoTime = photoTime

--- a/internal/layout/timeline.go
+++ b/internal/layout/timeline.go
@@ -60,8 +60,7 @@ func LayoutTimelineEvent(layout Layout, rect render.Rect, event *TimelineEvent, 
 	)
 	rect.Y += textHeight + 15
 
-	photos := addSectionPhotos(&event.Section, scene, source)
-	newBounds := layoutSectionPhotos(photos, rect, layout, scene, source)
+	newBounds := addSectionToScene(&event.Section, scene, rect, layout, source)
 
 	rect.Y = newBounds.Y + newBounds.H
 	rect.Y += 10

--- a/internal/layout/timeline.go
+++ b/internal/layout/timeline.go
@@ -126,6 +126,7 @@ func LayoutTimeline(layout Layout, collection collection.Collection, scene *rend
 
 		layoutCounter.Set(index)
 		index++
+		scene.FileCount = index
 	}
 	layoutPlaced()
 

--- a/internal/layout/wall.go
+++ b/internal/layout/wall.go
@@ -60,13 +60,13 @@ func LayoutWall(layout Layout, collection collection.Collection, scene *render.S
 	y := sceneMargin
 
 	layoutFinished := metrics.Elapsed("layout")
-	photos := addSectionPhotos(&section, scene, source)
-	newBounds := layoutSectionPhotos(photos, render.Rect{
+	bounds := render.Rect{
 		X: x,
 		Y: y,
 		W: scene.Bounds.W - sceneMargin*2,
 		H: scene.Bounds.H - sceneMargin*2,
-	}, layoutConfig, scene, source)
+	}
+	newBounds := addSectionToScene(&section, scene, bounds, layoutConfig, source)
 	layoutFinished()
 
 	scene.Bounds.H = newBounds.Y + newBounds.H + sceneMargin

--- a/internal/openapi/api.gen.go
+++ b/internal/openapi/api.gen.go
@@ -93,6 +93,9 @@ type Scene struct {
 	Bounds    *Bounds `json:"bounds,omitempty"`
 	FileCount *int    `json:"file_count,omitempty"`
 	Id        SceneId `json:"id"`
+
+	// True while the scene is loading and the dimensions are not yet known.
+	Loading *bool `json:"loading,omitempty"`
 }
 
 // SceneId defines model for SceneId.

--- a/internal/openapi/api.gen.go
+++ b/internal/openapi/api.gen.go
@@ -208,14 +208,11 @@ type ServerInterface interface {
 	// (GET /files/{id})
 	GetFilesId(w http.ResponseWriter, r *http.Request, id FileIdPathParam)
 
-	// (GET /files/{id}/image-variants/{size}/{filename})
-	GetFilesIdImageVariantsSizeFilename(w http.ResponseWriter, r *http.Request, id FileIdPathParam, size SizePathParam, filename FilenamePathParam)
-
 	// (GET /files/{id}/original/{filename})
 	GetFilesIdOriginalFilename(w http.ResponseWriter, r *http.Request, id FileIdPathParam, filename FilenamePathParam)
 
-	// (GET /files/{id}/video-variants/{size}/{filename})
-	GetFilesIdVideoVariantsSizeFilename(w http.ResponseWriter, r *http.Request, id FileIdPathParam, size SizePathParam, filename FilenamePathParam)
+	// (GET /files/{id}/variants/{size}/{filename})
+	GetFilesIdVariantsSizeFilename(w http.ResponseWriter, r *http.Request, id FileIdPathParam, size SizePathParam, filename FilenamePathParam)
 
 	// (GET /scenes)
 	GetScenes(w http.ResponseWriter, r *http.Request, params GetScenesParams)
@@ -317,50 +314,6 @@ func (siw *ServerInterfaceWrapper) GetFilesId(w http.ResponseWriter, r *http.Req
 	handler(w, r.WithContext(ctx))
 }
 
-// GetFilesIdImageVariantsSizeFilename operation middleware
-func (siw *ServerInterfaceWrapper) GetFilesIdImageVariantsSizeFilename(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var err error
-
-	// ------------- Path parameter "id" -------------
-	var id FileIdPathParam
-
-	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Invalid format for parameter id: %s", err), http.StatusBadRequest)
-		return
-	}
-
-	// ------------- Path parameter "size" -------------
-	var size SizePathParam
-
-	err = runtime.BindStyledParameter("simple", false, "size", chi.URLParam(r, "size"), &size)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Invalid format for parameter size: %s", err), http.StatusBadRequest)
-		return
-	}
-
-	// ------------- Path parameter "filename" -------------
-	var filename FilenamePathParam
-
-	err = runtime.BindStyledParameter("simple", false, "filename", chi.URLParam(r, "filename"), &filename)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Invalid format for parameter filename: %s", err), http.StatusBadRequest)
-		return
-	}
-
-	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetFilesIdImageVariantsSizeFilename(w, r, id, size, filename)
-	}
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler(w, r.WithContext(ctx))
-}
-
 // GetFilesIdOriginalFilename operation middleware
 func (siw *ServerInterfaceWrapper) GetFilesIdOriginalFilename(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -396,8 +349,8 @@ func (siw *ServerInterfaceWrapper) GetFilesIdOriginalFilename(w http.ResponseWri
 	handler(w, r.WithContext(ctx))
 }
 
-// GetFilesIdVideoVariantsSizeFilename operation middleware
-func (siw *ServerInterfaceWrapper) GetFilesIdVideoVariantsSizeFilename(w http.ResponseWriter, r *http.Request) {
+// GetFilesIdVariantsSizeFilename operation middleware
+func (siw *ServerInterfaceWrapper) GetFilesIdVariantsSizeFilename(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
@@ -430,7 +383,7 @@ func (siw *ServerInterfaceWrapper) GetFilesIdVideoVariantsSizeFilename(w http.Re
 	}
 
 	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetFilesIdVideoVariantsSizeFilename(w, r, id, size, filename)
+		siw.Handler.GetFilesIdVariantsSizeFilename(w, r, id, size, filename)
 	}
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -890,13 +843,10 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/files/{id}", wrapper.GetFilesId)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/files/{id}/image-variants/{size}/{filename}", wrapper.GetFilesIdImageVariantsSizeFilename)
-	})
-	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/files/{id}/original/{filename}", wrapper.GetFilesIdOriginalFilename)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/files/{id}/video-variants/{size}/{filename}", wrapper.GetFilesIdVideoVariantsSizeFilename)
+		r.Get(options.BaseURL+"/files/{id}/variants/{size}/{filename}", wrapper.GetFilesIdVariantsSizeFilename)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/scenes", wrapper.GetScenes)

--- a/internal/render/photo.go
+++ b/internal/render/photo.go
@@ -135,10 +135,11 @@ func (photo *Photo) getBestVariants(config *Render, scene *Scene, c *canvas.Cont
 func (photo *Photo) Draw(config *Render, scene *Scene, c *canvas.Context, scales Scales, source *image.Source) {
 
 	pixelArea := photo.Sprite.Rect.GetPixelArea(c, image.Size{X: 1, Y: 1})
-	path := photo.GetPath(source)
 	if pixelArea < config.MaxSolidPixelArea {
 		style := c.Style
 
+		// TODO: this can be a bottleneck for lots of images
+		// if it ends up hitting the database for each individual image
 		info := source.GetInfo(photo.Id)
 		style.FillColor = info.GetColor()
 
@@ -147,6 +148,7 @@ func (photo *Photo) Draw(config *Render, scene *Scene, c *canvas.Context, scales
 	}
 
 	drawn := false
+	path := photo.GetPath(source)
 	variants := photo.getBestVariants(config, scene, c, scales, source, path)
 	for _, variant := range variants {
 		// text := fmt.Sprintf("index %d zd %4.2f %s", index, bitmapAtZoom.ZoomDist, bitmap.Path)
@@ -193,7 +195,7 @@ func (photo *Photo) Draw(config *Render, scene *Scene, c *canvas.Context, scales
 			text := fmt.Sprintf("%dx%d %s", bounds.Size().X, bounds.Size().Y, variant.String())
 			font := scene.Fonts.Debug
 			font.Color = canvas.Lime
-			bitmap.Sprite.DrawText(c, scales, &font, text)
+			bitmap.Sprite.DrawText(config, c, scales, &font, text)
 		}
 
 		break

--- a/internal/render/scene.go
+++ b/internal/render/scene.go
@@ -127,7 +127,7 @@ func (scene *Scene) Draw(config *Render, c *canvas.Context, scales Scales, sourc
 
 	for i := range scene.Texts {
 		text := &scene.Texts[i]
-		text.Draw(c, scales)
+		text.Draw(config, c, scales)
 	}
 }
 

--- a/internal/render/scene.go
+++ b/internal/render/scene.go
@@ -194,5 +194,8 @@ func (scene *Scene) GetRegions(config *Render, bounds Rect, limit *int) []Region
 }
 
 func (scene *Scene) GetRegion(id int) Region {
+	if scene.RegionSource == nil {
+		return Region{}
+	}
 	return scene.RegionSource.GetRegionById(id, scene, RegionConfig{})
 }

--- a/internal/render/scene.go
+++ b/internal/render/scene.go
@@ -54,6 +54,7 @@ type SceneId = string
 type Scene struct {
 	Id           SceneId      `json:"id"`
 	CreatedAt    time.Time    `json:"created_at"`
+	Loading      bool         `json:"loading"`
 	Fonts        Fonts        `json:"-"`
 	Bounds       Rect         `json:"bounds"`
 	Photos       []Photo      `json:"-"`
@@ -181,6 +182,9 @@ func (scene *Scene) GetRegions(config *Render, bounds Rect, limit *int) []Region
 	}
 	if limit != nil {
 		query.Limit = *limit
+	}
+	if scene.RegionSource == nil {
+		return []Region{}
 	}
 	return scene.RegionSource.GetRegionsFromBounds(
 		bounds,

--- a/internal/render/sprite.go
+++ b/internal/render/sprite.go
@@ -66,9 +66,9 @@ func (sprite *Sprite) DrawWithStyle(c *canvas.Context, style canvas.Style) {
 	)
 }
 
-func (sprite *Sprite) DrawText(c *canvas.Context, scales Scales, font *canvas.FontFace, txt string) {
+func (sprite *Sprite) DrawText(config *Render, c *canvas.Context, scales Scales, font *canvas.FontFace, txt string) {
 	text := NewTextFromRect(sprite.Rect, font, txt)
-	text.Draw(c, scales)
+	text.Draw(config, c, scales)
 }
 
 func (sprite *Sprite) IsVisible(c *canvas.Context, scales Scales) bool {

--- a/internal/render/text.go
+++ b/internal/render/text.go
@@ -1,6 +1,10 @@
 package render
 
-import "github.com/tdewolff/canvas"
+import (
+	"photofield/internal/image"
+
+	"github.com/tdewolff/canvas"
+)
 
 type Text struct {
 	Sprite Sprite
@@ -16,8 +20,14 @@ func NewTextFromRect(rect Rect, font *canvas.FontFace, txt string) Text {
 	return text
 }
 
-func (text *Text) Draw(c *canvas.Context, scales Scales) {
+func (text *Text) Draw(config *Render, c *canvas.Context, scales Scales) {
 	if text.Sprite.IsVisible(c, scales) {
+		pixelArea := text.Sprite.Rect.GetPixelArea(c, image.Size{X: 1, Y: 1})
+		if pixelArea < config.MaxSolidPixelArea {
+			// Skip rendering small text
+			return
+		}
+
 		textLine := canvas.NewTextLine(*text.Font, text.Text, canvas.Left)
 		c.RenderText(textLine, c.View().Mul(text.Sprite.Rect.GetMatrix()))
 	}

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -96,11 +96,7 @@ export async function getFileBlob(id) {
 }
 
 export function getThumbnailUrl(id, size, filename) {
-  return `${host}/files/${id}/image-variants/${size}/${filename}`;
-}
-
-export function getVideoUrl(id, size, filename) {
-  return `${host}/files/${id}/video-variants/${size}/${filename}`;
+  return `${host}/files/${id}/variants/${size}/${filename}`;
 }
 
 export function useApi(getUrl, config) {

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -107,6 +107,10 @@ export function useApi(getUrl, config) {
   const response = useSWRV(getUrl, fetcher, config);
   const items = computed(() => response.data.value?.items);
   const itemsMutate = async getItems => {
+    if (!getItems) {
+      await response.mutate();
+      return;
+    } 
     const items = await getItems();
     await response.mutate(() => ({
       items,

--- a/ui/src/components/NaturalViewer.vue
+++ b/ui/src/components/NaturalViewer.vue
@@ -65,6 +65,7 @@
         :sceneParams="sceneParams"
         :flipX="contextFlipX"
         :flipY="contextFlipY"
+        :tileSize="tileSize"
         @close="closeContextMenu()"
       ></region-menu>
     </ContextMenu>

--- a/ui/src/components/NaturalViewer.vue
+++ b/ui/src/components/NaturalViewer.vue
@@ -2,7 +2,7 @@
   <div class="container" :class="{ fullpage, fixed: !nativeScroll }">
 
     <page-title :title="pageTitle"></page-title>
-    
+
     <tile-viewer
       class="viewer"
       ref="viewer"
@@ -18,6 +18,7 @@
       @keydown="onKeyDown"
       @contextmenu.prevent="onContext"
     ></tile-viewer>
+    
     <overlays
       :viewer="overlayViewer"
       :overlay="lastViewedRegion"
@@ -26,6 +27,15 @@
       @interactive="interactive => panDisabled = interactive"
       class="overlays"
     ></overlays>
+
+    <spinner
+      class="spinner"
+      :total="scene?.file_count"
+      :speed="sceneLoadFilesPerSecond"
+      :divider="10000"
+      :loading="scene?.loading"
+    ></spinner>
+    
     <div
       class="scroller"
       :class="{ disabled: !nativeScroll }"
@@ -76,6 +86,7 @@ import dateParseISO from 'date-fns/parseISO';
 import dateFormat from 'date-fns/format';
 import differenceInDays from 'date-fns/differenceInDays';
 import Overlays from './Overlays.vue';
+import Spinner from './Spinner.vue';
 
 export default {
 
@@ -101,6 +112,7 @@ export default {
     ContextMenu,
     RegionMenu,
     Overlays,
+    Spinner,
   },
 
   data() {
@@ -129,6 +141,7 @@ export default {
     const collectionId = toRef(props, "collectionId");
     const regionId = toRef(props, "regionId");
     const scrollbar = toRef(props, "scrollbar");
+    const sceneLoadFilesPerSecond = ref(0);
 
     const nativeScroll = ref(true);
 
@@ -200,6 +213,23 @@ export default {
       if (!list || list.length == 0) return null;
       return list[0];
     });
+    watch(scene, async (newValue, oldValue) => {
+      if (newValue?.loading) {
+        let prev = oldValue?.file_count || 0;
+        if (prev > newValue.file_count) {
+          prev = 0;
+        }
+        sceneLoadFilesPerSecond.value = newValue.file_count - prev;
+        sceneRefreshTask.perform();
+      } else {
+        sceneLoadFilesPerSecond.value = 0;
+      }
+    })
+    const sceneRefreshTask = useTask(function*() {
+      yield timeout(1000);
+      scenesMutate();
+    }).keepLatest()
+
 
     const regionSeekId = ref(null);
     const regionSeekApplyTask = useTask(function*(_, router) {
@@ -336,6 +366,7 @@ export default {
       collection,
       scene,
       scenes,
+      sceneLoadFilesPerSecond,
       region,
       regionSeekId,
       regionSeekApplyTask,
@@ -420,7 +451,13 @@ export default {
   },
   watch: {
     scene(newScene, oldScene) {
-      if (oldScene && newScene && oldScene.id == newScene.id) return;
+      if (
+        oldScene && newScene &&
+        oldScene.id == newScene.id &&
+        oldScene.file_count == newScene.file_count
+      ) {
+        return;
+      }
       this.$emit("scene", newScene);
       if (newScene) {
         this.pushScrollToView();
@@ -976,6 +1013,14 @@ export default {
 
 <style scoped>
 
+.spinner {
+  position: fixed;
+  --size: 200px;
+  top: calc(50% - var(--size)/2);
+  left: calc(50% - var(--size)/2);
+  width: var(--size);
+  height: var(--size);
+}
 .container {
   position: relative;
 }

--- a/ui/src/components/NaturalViewer.vue
+++ b/ui/src/components/NaturalViewer.vue
@@ -528,10 +528,12 @@ export default {
 
     addFullpageListeners() {
       window.addEventListener('scroll', this.onScroll);
+      window.addEventListener('resize', this.onWindowResize);
     },
 
     removeFullpageListeners() {
       window.removeEventListener('scroll', this.onScroll);
+      window.removeEventListener('resize', this.onWindowResize);
     },
 
     attachScrollbar(scrollbar) {
@@ -651,9 +653,13 @@ export default {
 
     onResize(rect) {
       if (rect.width == 0 || rect.height == 0) return;
+      this.resizeApplyTask.perform(rect, this.pushScrollToView);
+    },
+
+    onWindowResize(rect) {
+      if (rect.width == 0 || rect.height == 0) return;
       const vh = window.innerHeight * 0.01;
       document.documentElement.style.setProperty('--vh', `${vh}px`);
-      this.resizeApplyTask.perform(rect, this.pushScrollToView);
     },
 
     onScroll(event) {

--- a/ui/src/components/NaturalViewer.vue
+++ b/ui/src/components/NaturalViewer.vue
@@ -929,12 +929,14 @@ export default {
 
       const viewMaxY = (this.scene?.bounds?.h || 0) - this.window.height + this.marginTop;
       
+      let scrollY = 0;
       if (scrollRatio == null) {
         if (this.scrollbar) {
           const scroll = this.scrollbar.scroll();
           // Uncomment for scroll position debugging
           // console.log(scroll.position, scroll.max, scroll.ratio, scroll.position.y / viewMaxY)
-          scrollRatio = scroll.position.y / viewMaxY;
+          scrollRatio = scroll.ratio.y;
+          scrollY = scroll.position.y;
         } else {
           const scroller = this.$refs.scroller;
           const scrollMaxY = 
@@ -946,6 +948,7 @@ export default {
               window.scrollY :
               scroller.scrollTop;
           scrollRatio = scrollMaxY ? scrollTop / scrollMaxY : 0;
+          scrollY = scrollTop;
         }
       }
 
@@ -962,7 +965,7 @@ export default {
       this.$refs.viewer.setView(view, transition && { animationTime: transition });
       
       // Offset the native browser scroll to keep the viewer visible
-      this.$refs.viewer.$el.style.transform = `translate(0, ${viewY}px)`;
+      this.$refs.viewer.$el.style.transform = `translate(0, ${scrollY}px)`;
 
       this.visibleRegionsTask.perform(view, this.sceneParams);
     },

--- a/ui/src/components/NaturalViewer.vue
+++ b/ui/src/components/NaturalViewer.vue
@@ -214,6 +214,7 @@ export default {
       if (!list || list.length == 0) return null;
       return list[0];
     });
+    const sceneRefreshCount = ref(0);
     watch(scene, async (newValue, oldValue) => {
       if (newValue?.loading) {
         let prev = oldValue?.file_count || 0;
@@ -223,11 +224,16 @@ export default {
         sceneLoadFilesPerSecond.value = newValue.file_count - prev;
         sceneRefreshTask.perform();
       } else {
+        sceneRefreshCount.value = 0;
         sceneLoadFilesPerSecond.value = 0;
       }
     })
+    const sceneRefreshDelays = [10, 50, 100, 200, 500, 1000];
     const sceneRefreshTask = useTask(function*() {
-      yield timeout(1000);
+      const count = sceneRefreshCount.value;
+      const delay = sceneRefreshDelays[Math.min(sceneRefreshDelays.length - 1, count)];
+      sceneRefreshCount.value = count + 1;
+      yield timeout(delay);
       scenesMutate();
     }).keepLatest()
 

--- a/ui/src/components/RegionMenu.vue
+++ b/ui/src/components/RegionMenu.vue
@@ -46,7 +46,7 @@
           v-for="thumb in region.data?.thumbnails"
           :key="thumb.name"
           class="thumbnail"
-          :href="getThumbnailUrl(region.data.id, thumb.name, region.data.filename)"
+          :href="getThumbnailUrl(region.data.id, thumb.name, thumb.filename)"
           target="_blank"
         >
           {{ thumb.width }}

--- a/ui/src/components/RegionMenu.vue
+++ b/ui/src/components/RegionMenu.vue
@@ -12,7 +12,7 @@
         :interactive="false"
         :immediate="false"
         :scene="scene"
-        :tileSize="256"
+        :tileSize="tileSize"
         :view="region.bounds"
         :style="{ height: imageHeight + 'px' }"
       ></tile-viewer>
@@ -69,7 +69,7 @@ import ExpandButton from './ExpandButton.vue';
 import { getFileBlob, getFileUrl, getThumbnailUrl } from '../api';
 
 export default {
-  props: ["region", "scene", "flipX", "flipY"],
+  props: ["region", "scene", "flipX", "flipY", "tileSize"],
   emits: ["close"],
   components: { TileViewer, ExpandButton },
   data() {

--- a/ui/src/components/Spinner.vue
+++ b/ui/src/components/Spinner.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="spinner" :class="{ hidden: !loading || !visible, removed: !visible }">
     <div class="label">
-      <template v-if="loading">{{ interpolatedTotal && Math.round(interpolatedTotal).toLocaleString() }} files</template>
+      <template v-if="loading && total == 0">Loading</template>
+      <template v-else-if="loading">{{ interpolatedTotal && Math.round(interpolatedTotal).toLocaleString() }} files</template>
       <template v-else>{{ total && total.toLocaleString() }} files</template>
     </div>
     <svg :viewBox="`0 0 ${width} ${height}`" xmlns="http://www.w3.org/2000/svg">
@@ -32,7 +33,7 @@ export default {
 
   data() {
     return {
-      startDelay: 800,
+      startDelay: 500,
       finishRemoveDelay: 2000,
       smoothSpeedEasing: 0.95,
       aspectRatios: [

--- a/ui/src/components/Spinner.vue
+++ b/ui/src/components/Spinner.vue
@@ -1,0 +1,249 @@
+<template>
+  <div class="spinner" :class="{ hidden: !loading || !visible, removed: !visible }">
+    <div class="label">
+      <template v-if="loading">{{ interpolatedTotal && Math.round(interpolatedTotal).toLocaleString() }} files</template>
+      <template v-else>{{ total && total.toLocaleString() }} files</template>
+    </div>
+    <svg :viewBox="`0 0 ${width} ${height}`" xmlns="http://www.w3.org/2000/svg">
+      <rect
+        v-for="r in rects"
+        :key="r.id"
+        ref="rects"
+        :x="r.x"
+        :y="y + r.y + (1 - easeOutExpo(Math.min(1, (now - r.t)/1000)) * 100)"
+        :opacity="easeOutExpo((now - r.t)/1000 * 2)"
+        :width="r.w"
+        :height="r.h"
+        fill="#999"
+      ></rect>
+    </svg>
+  </div>
+</template>
+
+<script>
+export default {
+
+  props: {
+    total: Number,
+    speed: Number,
+    divider: Number,
+    loading: Boolean,
+  },
+
+  data() {
+    return {
+      startDelay: 800,
+      finishRemoveDelay: 2000,
+      smoothSpeedEasing: 0.95,
+      aspectRatios: [
+        { weight: 10, ratio: 4/3 },
+        { weight: 4, ratio: 3/4 },
+        { weight: 8, ratio: 10/16 },
+      ],
+      rowHeight: 180,
+      spacing: 10,
+      newRowHeightThreshold: 0.8,
+      minRowItems: 3,
+
+      minSpeed: 0.05,
+      maxSpeed: 2,
+      width: 1000,
+      height: 1000,
+
+      poolSize: 60,
+
+      interpolatedTotal: 0,
+      smoothSpeed: 0,
+      y: 0,
+      now: 0,
+      rects: [],
+      startTime: 0,
+      finishTime: 0,
+      running: false,
+      visible: false,
+    }
+  },
+
+  mounted() {
+    this.setupAspectRatios();
+
+    this.lastTotal = 0;
+    this.lastTotalTime = Date.now();
+
+    for (let i = 0; i < this.poolSize; i++) {
+      this.rects.push({ id: `r${i}`, x: 0, y: -1, w: 0.1, h: 0.1, t: 0 });
+    }
+
+    this.row = { rects: this.rects.slice(0, 10), x: 0, y: 60, spacing: this.spacing };
+  },
+
+  unmounted() {
+    this.running = false;
+  },
+
+  watch: {
+    loading: {
+      immediate: true,
+      handler(newValue, oldValue) {
+        if (newValue == oldValue) return;
+        const now = Date.now();
+        if (newValue) {
+          if (this.running) return;
+          this.startTime = now;
+          this.last = now;
+          this.running = true;
+          requestAnimationFrame(this.frame);
+        } else {
+          this.finishTime = now;
+        }
+      },
+    },
+    total: {
+      immediate: true,
+      handler(newValue, oldValue) {
+        this.lastTotal = oldValue < newValue ? oldValue : newValue;
+        this.lastTotalTime = Date.now();
+      },
+    },
+  },
+
+  methods: {
+    easeOutExpo(x) {
+      return x === 1 ? 1 : 1 - Math.pow(2, -10 * x);
+    },
+    setupAspectRatios() {
+      let totalWeight = this.aspectRatios.reduce((total, a) => total + a.weight, 0);
+      let sum = 0;
+      this.aspectRatios.forEach(a => {
+        sum += a.weight;
+        a.cumulativeWeight = sum / totalWeight;
+      });
+    },
+    getRandomSize() {
+      const pick = Math.random();
+      for (let i = 0; i < this.aspectRatios.length; i++) {
+        const a = this.aspectRatios[i];
+        if (a.cumulativeWeight >= pick || i == this.aspectRatios.length - 1) {
+          const h = 100;
+          const w = h * a.ratio;
+          return { w, h };
+        }
+      }
+    },
+    addRow({ rects, x, y, spacing }) {
+      const boundsWidth = this.width;
+      let remaining = [];
+      const now = Date.now();
+      for (let i = 0; i < rects.length; i++) {
+        const r = rects[i];
+        r.x = x;
+        r.y = y;
+        r.t = now + 200 + Math.random() * 100;
+
+        const size = this.getRandomSize();
+        r.w = size.w;
+        r.h = size.h;
+        
+        const scale = this.rowHeight / r.h;
+        r.w *= scale;
+        r.h *= scale;
+        
+        x += r.w + spacing;
+        if (x >= boundsWidth) {
+          remaining = rects.slice(i + 1);
+          rects = rects.slice(0, i + 1);
+          break;
+        }
+      }
+      const rowWidth = x - spacing;
+      const totalSpacing = (rects.length - 1) * spacing; 
+      const scale = (boundsWidth - totalSpacing) / (rowWidth - totalSpacing);
+      x = 0;
+      for (let i = 0; i < rects.length; i++) {
+        const r = rects[i];
+        r.x = x;
+        r.w *= scale;
+        r.h *= scale;
+        x += r.w + spacing;
+      }
+      x = 0;
+      y += this.rowHeight * scale + spacing;
+      return { rects: remaining, x, y, spacing };
+    },
+    frame() {
+      const now = Date.now();
+      this.now = now;
+
+      if (now < this.startTime + this.startDelay) {
+        if (!this.loading) this.running = false;
+        if (this.running) requestAnimationFrame(this.frame);
+        return;
+      }
+      this.visible = true;
+
+      const dt = (now - this.last)/1000;
+      const rects = this.rects;
+
+      this.interpolatedTotal = this.lastTotal + (this.total - this.lastTotal) * Math.min(1, (now - this.lastTotalTime) / 1000);
+
+      const boundedSpeed = this.speed == 0 ? 0 : Math.min(this.maxSpeed, Math.max(this.minSpeed, this.speed / this.divider));
+      this.smoothSpeed += (boundedSpeed - this.smoothSpeed) * this.smoothSpeedEasing * dt;
+      if (!this.loading) {
+        this.smoothSpeed *= 0.9;
+      }
+
+      this.y += -this.smoothSpeed * this.height * dt;
+
+      const outOfBounds = [];
+      for (let i = 0; i < rects.length; i++) {
+        const r = rects[i];
+        const bottom = this.y + r.y + r.h;
+        if (bottom < 0) {
+          outOfBounds.push(r);
+        }
+      }
+      const lowest = this.y + this.row.y;
+
+      if (this.loading && lowest < this.height * this.newRowHeightThreshold) {
+        this.row.rects = outOfBounds;
+        this.row = this.addRow(this.row);
+      }
+
+      if (!this.loading && (now - this.finishTime) > this.finishRemoveDelay) {
+        this.running = false;
+        this.visible = false;
+      }
+
+      this.last = now;
+      if (this.running) requestAnimationFrame(this.frame);
+    }
+  }
+
+};
+</script>
+
+<style scoped>
+
+.spinner {
+  background: white;
+  box-sizing: border-box;
+  padding: 12px;
+  border-radius: 5px;
+  transition: opacity 1s cubic-bezier(1,0,.86,0);
+}
+
+.hidden {
+  opacity: 0
+}
+
+.removed {
+  display: none;
+}
+
+.label {
+  width: 100%;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+</style>

--- a/ui/src/components/TileViewer.vue
+++ b/ui/src/components/TileViewer.vue
@@ -44,7 +44,13 @@ export default {
   watch: {
 
     scene(newScene, oldScene) {
-      if (newScene?.id == oldScene?.id) return;
+      if (
+        newScene?.id == oldScene?.id &&
+        newScene.bounds.w == oldScene.bounds.w &&
+        newScene.bounds.h == oldScene.bounds.h
+      ) {
+        return;
+      }
       this.reset();
     },
 

--- a/ui/src/components/TileViewer.vue
+++ b/ui/src/components/TileViewer.vue
@@ -308,12 +308,10 @@ export default {
         });
       }
     },
-    
-    getTiledImage() {
+
+    getTiledImageSizeAtLevel(level) {
       const tileSize = this.tileSize;
-      const minLevel = 0;
-      const maxLevel = 30;
-      const power = 1 << maxLevel;
+      const power = 1 << level;
       let width = power*tileSize;
       let height = power*tileSize;
       const sceneAspect = this.scene.bounds.w / this.scene.bounds.h;
@@ -322,8 +320,29 @@ export default {
       } else {
         height = width / sceneAspect;
       }
+      return { width, height }
+    },
+    
+    getTiledImage() {
+      const tileSize = this.tileSize;
+      let minLevel = 0;
+      const maxLevel = 30;
+      
+      const { width, height } = this.getTiledImageSizeAtLevel(maxLevel);
       if (width < 1) width = 1;
       if (height < 1) height = 1;
+      
+      // Limit minimum size loaded to avoid
+      // loading tiled images with very little content
+      const minTiledImageWidth = 10;
+      for (let i = 0; i < maxLevel; i++) {
+        const levelSize = this.getTiledImageSizeAtLevel(i);
+        if (levelSize.width >= minTiledImageWidth) {
+          minLevel = i;
+          break;
+        }
+      }
+
       return {
         width,
         height,

--- a/ui/src/components/VideoPlayer.vue
+++ b/ui/src/components/VideoPlayer.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import { getFileUrl, getVideoUrl } from '../api';
+import { getFileUrl, getThumbnailUrl } from '../api';
 import Plyr from 'plyr';
 import { isCloseClick } from '../utils';
 
@@ -106,10 +106,12 @@ export default {
           }
         ]
         .concat(
-          this.region?.data?.thumbnails?.map(thumbnail => ({
-            src: getVideoUrl(this.region.data.id, thumbnail.name, this.region.data.filename),
-            size: thumbnail.height,
-          })) || []
+          this.region?.data?.thumbnails
+            ?.filter(thumbnail => thumbnail.filename.endsWith(".mp4"))
+            .map(thumbnail => ({
+              src: getThumbnailUrl(this.region.data.id, thumbnail.name, this.region.data.filename),
+              size: thumbnail.height,
+            })) || []
         ),
       }
     }


### PR DESCRIPTION
Loading large collections can be way faster now (loads at 100k-1000k or more photos / second).

Collections of more than 100M photos should also work, but as I don't have that many photos I've only been able to try it by adding a hack to repeat a 40k collection thousands of times.

There is a frontend-based loader now while a scene is loading. This makes it more obvious what's going on without checking the logs.
![PhotofieldMillions2](https://user-images.githubusercontent.com/1451391/179320785-bfb37545-edc6-419c-95b0-d8762b57d185.gif)

Image/video thumbnails/variants have been refactored to fix some issues with the previous setup. The configuration has changed slightly to support this. Video thumbnails should also show up faster and throw fewer errors in the logs now.