### PR TITLE
Preload all scrollbar dates and UI update

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -195,6 +195,37 @@ paths:
                 type: string
                 format: binary
 
+  /scenes/{scene_id}/dates:
+    get:
+      description: Get layout photo dates
+      tags: ["Display"]
+      parameters:
+
+        - name: scene_id
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/SceneId"
+
+        - name: height
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            example: 1920
+
+      responses:
+        "200":
+          description: OK
+          content:
+            "application/octet-stream":
+              schema:
+                type: string
+                format: binary
+                description: List of `height` uint32-encoded Unix timestamps of photos in the layout
+
   /scenes/{scene_id}/regions:
     get:
       description: Get regions within a certain bounding box

--- a/internal/render/scene.go
+++ b/internal/render/scene.go
@@ -131,6 +131,26 @@ func (scene *Scene) Draw(config *Render, c *canvas.Context, scales Scales, sourc
 	}
 }
 
+func (scene *Scene) GetTimestamps(height int, source *image.Source) []uint32 {
+	scale := float64(height) / scene.Bounds.H
+	timestamps := make([]uint32, height)
+
+	i := 0
+	ty := -1.
+	var t time.Time
+	for y := 0; y < height; y++ {
+		for ; ty <= float64(y) && i < len(scene.Photos); i++ {
+			photo := scene.Photos[i]
+			info := photo.GetInfo(source)
+			t = info.DateTime
+			ty = (photo.Sprite.Rect.Y + photo.Sprite.Rect.H) * scale
+		}
+		timestamps[y] = uint32(t.Unix())
+	}
+
+	return timestamps
+}
+
 func (scene *Scene) AddPhotosFromIds(ids <-chan image.ImageId) {
 	for id := range ids {
 		photo := Photo{}

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -271,7 +271,6 @@ export default {
         clickScrolling: true,
       },
     });
-    this.scrollbar.addExt("timeline");
   },
   watch: {
     collection(newCollection, oldCollection) {

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -119,6 +119,19 @@ export function useApi(getUrl, config) {
   }
 }
 
+async function bufferFetcher(endpoint) {
+  const response = await fetch(host + endpoint);
+  if (!response.ok) {
+    console.error(response);
+    throw new Error(response.statusText);
+  }
+  return await response.arrayBuffer();
+}
+
+export function useBufferApi(getUrl, config) {
+  return useSWRV(getUrl, bufferFetcher, config);
+}
+
 export function useTasks() {
   const intervalMs = 250;
   const response = useApi(

--- a/ui/src/components/DateStrip.vue
+++ b/ui/src/components/DateStrip.vue
@@ -1,0 +1,55 @@
+<template>
+  <div
+    class="date-strip"
+    v-if="date"
+  >
+    <div class="year">{{ dateFormat(date, "yyyy") }}</div>
+    <div class="month">{{ dateFormat(date, "MMM") }}</div>
+    <div class="day">{{ dateFormat(date, "d") }}</div>
+    <div class="weekday">{{ dateFormat(date, "EEE") }}</div>
+    <div class="time">{{ dateFormat(date, "HH:mm") }}</div>
+  </div>
+    
+</template>
+
+<script>
+import dateFormat from 'date-fns/format';
+
+export default {
+  props: ["date"],
+  methods: {
+    dateFormat,
+  }
+};
+
+</script>
+
+<style scoped>
+
+.date-strip {
+  background: white;
+  padding: 10px;
+  text-align: center;
+}
+
+.month {
+  font-size: 1.4em;
+}
+
+.day {
+  font-size: 2em;
+}
+
+.year, .weekday {
+  font-size: 0.9em;
+  color: #666;
+}
+
+.time {
+  font-size: 1em;
+  margin-top: 12px;
+  letter-spacing: 1px;
+  color: #666;
+}
+
+</style>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -12,8 +12,6 @@ import "./os-theme-minimal-dark.css";
 import "./os-theme-customizations.css";
 
 import "overlayscrollbars";
-import "./scrollbar-timeline-ext.js";
-import "./scrollbar-timeline-ext.css";
 
 import "plyr/dist/plyr.css";
 

--- a/ui/src/os-theme-customizations.css
+++ b/ui/src/os-theme-customizations.css
@@ -1,8 +1,7 @@
 .os-theme-minimal-dark > .os-scrollbar > .os-scrollbar-track > .os-scrollbar-handle:before {
-  border-top-left-radius: 8px;
-  border-bottom-left-radius: 8px;
+  right: 2px;
 }
 
 .os-theme-minimal-dark > .os-scrollbar-vertical > .os-scrollbar-track > .os-scrollbar-handle {
-  min-height: 28px;
+  min-height: 32px;
 }


### PR DESCRIPTION
The scrollbar dates don't need a server check to load anymore as they are all preloaded on scene load. The UI has been changed so that instead of the dates showing up next to the scrollbar, they are fixed to the top left corner and only show up while scrolling quickly (similar to Google Photos on mobile).

![PhotofieldScrollbar3](https://user-images.githubusercontent.com/1451391/180883011-c6e192d7-d508-4210-9691-24235e7bfda4.gif)