### PR TITLE
EXIF tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ layouts.
   * [x] **Custom tags**. You canadd your own tags to photos, e.g. `#family` or
     `#vacation`. Batch tagging not supported yet, but should be relatively easy
     to add considering the selections (above) are already tags.
-  * [ ] **EXIF tags**. Tags could be automatically added from the EXIF data, e.g.
-    `exif:make:sony` or `exif:model:sm-g950f`.
+  * [x] **EXIF tags**. Tags are automatically added from the EXIF data, e.g.
+    `exif:make:sony` or `exif:model:sm-g950f`. You need to enable this in the
+    `exif` section of the [configuration]. Only `make` and `model` are currently
+    supported (hardcoded).
   * [ ] **Location tags**. Photos could be automatically tagged with the
     location, e.g. `city:berlin` or `country:germany`. See #59.
   * [ ] **Filter by tags**. You could filter by a tag, e.g. `#beach` to only

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -52,6 +52,9 @@ tags:
   #
   # enable: true
 
+  # exif:
+  #   enable: true
+
 media:
   # Extract metadata from this many files concurrently
   concurrent_meta_loads: 8

--- a/internal/image/database.go
+++ b/internal/image/database.go
@@ -307,7 +307,7 @@ func (source *Database) writePendingInfosSqlite() {
 	}()
 
 	commitTicker := &time.Ticker{}
-	commitInterval := 100 * time.Millisecond
+	commitInterval := 200 * time.Millisecond
 
 	for {
 		select {
@@ -318,10 +318,8 @@ func (source *Database) writePendingInfosSqlite() {
 			}
 
 			if pendingCompactionTags.Len() > 0 {
-				compactions := make([]<-chan struct{}, 0, pendingCompactionTags.Len())
 				for id := range pendingCompactionTags {
-					c := source.CompactTag(id)
-					compactions = append(compactions, c)
+					source.CompactTag(id)
 				}
 				pendingCompactionTags = tagSet{}
 				continue

--- a/internal/image/database.go
+++ b/internal/image/database.go
@@ -13,7 +13,6 @@ import (
 
 	"photofield/internal/clip"
 	"photofield/internal/metrics"
-	"photofield/search"
 	"photofield/tag"
 
 	"zombiezen.com/go/sqlite"
@@ -37,7 +36,6 @@ const (
 type ListOptions struct {
 	OrderBy ListOrder
 	Limit   int
-	Tags    search.Where
 }
 
 type Database struct {

--- a/internal/image/decoder.go
+++ b/internal/image/decoder.go
@@ -6,6 +6,7 @@ import (
 	"image/jpeg"
 	"io"
 	"log"
+	"photofield/tag"
 	"strconv"
 	"time"
 )
@@ -16,7 +17,7 @@ type Decoder struct {
 }
 
 type metadataLoader interface {
-	DecodeInfo(path string, info *Info) error
+	DecodeInfo(path string, info *Info) ([]tag.Tag, error)
 	DecodeBytes(path string, tagName string) ([]byte, error)
 	Close()
 }
@@ -69,13 +70,8 @@ func parseDateTime(value string) (t time.Time, hasTimezone bool, hasSubsec bool,
 	return
 }
 
-func (decoder *Decoder) DecodeInfo(path string, info *Info) error {
-	err := decoder.loader.DecodeInfo(path, info)
-	// println(path, info.Width, info.Height, info.DateTime.String())
-	// if info.Width != 0 {
-	// 	println(path, info.String())
-	// }
-	return err
+func (decoder *Decoder) DecodeInfo(path string, info *Info) ([]tag.Tag, error) {
+	return decoder.loader.DecodeInfo(path, info)
 }
 
 func (decoder *Decoder) DecodeImage(path string, tagName string) (goimage.Image, Info, error) {

--- a/internal/image/goexif-rwcarlsen.go
+++ b/internal/image/goexif-rwcarlsen.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"io"
 	"os"
+	"photofield/tag"
 
 	"github.com/rwcarlsen/goexif/exif"
 )
@@ -28,13 +29,13 @@ func getOrientationFromExif(x *exif.Exif) string {
 	return "1"
 }
 
-func (decoder *GoExifRwcarlsenLoader) DecodeInfo(path string, info *Info) error {
+func (decoder *GoExifRwcarlsenLoader) DecodeInfo(path string, info *Info) ([]tag.Tag, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer file.Close()
-	return decoder.DecodeInfoReader(file, info)
+	return nil, decoder.DecodeInfoReader(file, info)
 }
 
 func (decoder *GoExifRwcarlsenLoader) DecodeInfoReader(r io.ReadSeeker, info *Info) error {

--- a/internal/image/indexMetadata.go
+++ b/internal/image/indexMetadata.go
@@ -17,7 +17,9 @@ func (source *Source) indexMetadata(in <-chan interface{}) {
 			continue
 		}
 		source.database.Write(path, info, UpdateMeta)
-		source.database.WriteTags(id, tags)
+		if source.Config.TagConfig.Exif.Enable {
+			source.database.WriteTags(id, tags)
+		}
 		source.imageInfoCache.Delete(id)
 	}
 }

--- a/internal/image/indexMetadata.go
+++ b/internal/image/indexMetadata.go
@@ -11,12 +11,13 @@ func (source *Source) indexMetadata(in <-chan interface{}) {
 		path := m.Path
 
 		var info Info
-		err := source.decoder.DecodeInfo(path, &info)
+		tags, err := source.decoder.DecodeInfo(path, &info)
 		if err != nil {
 			fmt.Println("Unable to load image info meta", err, path)
 			continue
 		}
 		source.database.Write(path, info, UpdateMeta)
+		source.database.WriteTags(id, tags)
 		source.imageInfoCache.Delete(id)
 	}
 }

--- a/internal/image/source.go
+++ b/internal/image/source.go
@@ -107,8 +107,9 @@ type Caches struct {
 }
 
 type Config struct {
-	DataDir string
-	AI      clip.AI
+	DataDir   string
+	AI        clip.AI
+	TagConfig tag.Config `json:"-"`
 
 	ExifToolCount        int  `json:"exif_tool_count"`
 	SkipLoadInfo         bool `json:"skip_load_info"`

--- a/main.go
+++ b/main.go
@@ -1062,6 +1062,7 @@ func loadConfiguration(path string) AppConfig {
 	}
 
 	appConfig.Media.AI = appConfig.AI
+	appConfig.Tags.Enable = appConfig.Tags.Enable || appConfig.Tags.Enabled
 
 	return appConfig
 }
@@ -1186,8 +1187,7 @@ func main() {
 
 	appConfig := loadConfiguration(configurationPath)
 	appConfig.Media.DataDir = dataDir
-
-	tagsEnabled = appConfig.Tags.Enabled
+	tagsEnabled = appConfig.Tags.Enable
 
 	if len(appConfig.Collections) > 0 {
 		defaultSceneConfig.Collection = appConfig.Collections[0]

--- a/tag/config.go
+++ b/tag/config.go
@@ -1,5 +1,12 @@
 package tag
 
 type Config struct {
+	Enable bool `json:"enable"`
+
+	// Deprecated: Use Enable instead, this is for backwards compatibility
 	Enabled bool `json:"enabled"`
+
+	Exif struct {
+		Enable bool `json:"enable"`
+	} `json:"exif"`
 }

--- a/tag/exif.go
+++ b/tag/exif.go
@@ -1,0 +1,70 @@
+package tag
+
+import (
+	"fmt"
+	"strconv"
+	"unicode"
+
+	"github.com/gosimple/slug"
+)
+
+var exifNames = []string{
+	"Make",
+	"Model",
+	// "ISO",
+	// "ShutterSpeed",
+	// "Aperture",
+	// "ExposureCompensation",
+	// "FocalLength35efl",
+	// "FocusMode",
+	// "WhiteBalance",
+	// "MeteringMode",
+	// "SelfTimer",
+}
+
+var exifSlugs []string
+var ExifTagToName = map[string]string{}
+var ExifFlags []string
+
+func init() {
+	for _, name := range exifNames {
+		slug := pascalCaseToKebabCase(name)
+		exifSlugs = append(exifSlugs, slug)
+		ExifTagToName[name] = slug
+		ExifFlags = append(ExifFlags, fmt.Sprintf("-%s", name))
+	}
+}
+
+func pascalCaseToKebabCase(s string) string {
+	var result []rune
+	lastUpper := false
+	lastDigit := false
+	for i, r := range s {
+		upper := unicode.IsUpper(r)
+		digit := unicode.IsDigit(r)
+		if upper || digit {
+			if i > 0 && !lastUpper && !lastDigit {
+				result = append(result, '-')
+			}
+			result = append(result, unicode.ToLower(r))
+		} else {
+			result = append(result, r)
+		}
+		lastUpper = upper
+		lastDigit = digit
+	}
+	return string(result)
+}
+
+func NewExif(name string, value string) Tag {
+	var t Tag
+	v := ""
+	_, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		v = value
+	} else {
+		v = slug.Make(value)
+	}
+	t.Name = fmt.Sprintf("exif:%s:%s", name, v)
+	return t
+}

--- a/tag/selection.go
+++ b/tag/selection.go
@@ -1,0 +1,15 @@
+package tag
+
+import "fmt"
+
+func NewSelection(collectionId string) (Tag, error) {
+	var t Tag
+
+	rand, err := randomId()
+	if err != nil {
+		return t, err
+	}
+
+	t.Name = fmt.Sprintf("sys:select:col:%s:%s", collectionId, rand)
+	return t, nil
+}

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -28,18 +28,6 @@ func randomId() (string, error) {
 	return gonanoid.Generate("6789BCDFGHJKLMNPQRTWbcdfghjkmnpqrtwz", 10)
 }
 
-func NewSelection(collectionId string) (Tag, error) {
-	var t Tag
-
-	rand, err := randomId()
-	if err != nil {
-		return t, err
-	}
-
-	t.Name = fmt.Sprintf("sys:select:col:%s:%s", collectionId, rand)
-	return t, nil
-}
-
 func (t Tag) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ExternalTag{
 		Id:       t.NameRev(),


### PR DESCRIPTION
Automatically add tags from EXIF data.

The only EXIF tags are the currently hardcoded `make` and `model`, and they are added to the file as `exif:make:<make>` and `exif:model:<model>` tags respectively.

To enable the automatic addition of these tags, you need to enable it in the config.
```yaml
tags:
  enable: true
  exif:
    enable: true
```

Bonus: this PR also fixes the root `enable`, as only `enabled` worked before. `enabled` will keep working for now to not break existing configurations.