### PR TITLE
Build for x64 & arm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+
+      - name: Set up QEMU for Multiarch Builds
+        uses: docker/setup-qemu-action@v3
+
       - name: Run GoReleaser (Push)
         if: github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,43 @@ builds:
       - embedgeo
 dockers:
   - dockerfile: Dockerfile-goreleaser
+    use: buildx
     image_templates:
-      - "ghcr.io/smilyorg/photofield:{{ .Tag }}"
-      - "ghcr.io/smilyorg/photofield:v{{ .Major }}"
-      - "ghcr.io/smilyorg/photofield:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/smilyorg/photofield:latest"
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+
+  - dockerfile: Dockerfile-goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/smilyorg/photofield:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-amd64"
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/smilyorg/photofield:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-amd64"
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-arm64"
+      
+  - name_template: "ghcr.io/smilyorg/photofield:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-amd64"
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-arm64"
+      
+  - name_template: "ghcr.io/smilyorg/photofield:latest"
+    image_templates:
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-amd64"
+      - "ghcr.io/smilyorg/photofield:{{ .Tag }}-arm64"
+
 archives:  
   - format: zip
     name_template: >-


### PR DESCRIPTION
This pull request includes changes to enable building for both x64 and arm architectures. It adds support for multiarch builds using QEMU and Docker buildx. The Docker images are tagged with the respective architecture (amd64 or arm64) and are pushed to the GitHub Container Registry.