### PR TITLE
Don't consider timezone-aware fields specially

### DIFF
--- a/internal/image/exiftool-mostlygeek.go
+++ b/internal/image/exiftool-mostlygeek.go
@@ -114,7 +114,7 @@ func (decoder *ExifToolMostlyGeekLoader) DecodeInfo(path string, info *Info) ([]
 			if strings.Contains(name, "Date") || strings.Contains(name, "Time") {
 				if info.DateTime.IsZero() {
 					info.DateTime, _, _, _ = parseDateTime(value)
-				} else if name != "FileModifyDate" && name != "FileCreateDate" {
+				} else if name != "GPSDateTime" && name != "FileModifyDate" && name != "FileCreateDate" {
 					// Prefer time with timezone if available
 					t, hasTimezone, _, _ := parseDateTime(value)
 					if hasTimezone && info.DateTime.Location() == time.UTC {


### PR DESCRIPTION
Currently, timestamp metadata fields later in the preferred field list can override earlier ones if the later one contains a timezone.  This causes `GPSDateTime` to override `DateTimeOriginal`, though in practice the GPS timestamps only ever seem to use UTC (= `Z`) rather than any locale-aware timezones.

This excludes `GPSDateTime` from being preferred just because it has a timestamp (it'll still be used in the absence of other fields).

Fixes #99.