### PR TITLE
Add Flex and Highlights layouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90 // indirect
+	github.com/gammazero/deque v0.2.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.2-0.20230929213430-5239be55a219
 	github.com/docker/go-units v0.4.0
 	github.com/felixge/fgprof v0.9.1
+	github.com/gammazero/deque v0.2.1
 	github.com/go-chi/chi/v5 v5.0.4
 	github.com/go-chi/cors v1.2.0
 	github.com/go-chi/render v1.0.1
@@ -55,7 +56,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90 // indirect
-	github.com/gammazero/deque v0.2.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.3-0.20170329110642-4da3e2cfbabc/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/clip/ai.go
+++ b/internal/clip/ai.go
@@ -30,7 +30,7 @@ func (e embedding) Byte() []byte {
 }
 
 func (e embedding) Float() []Float {
-	if e.bytes == nil {
+	if e.bytes == nil || len(e.bytes) == 0 {
 		return nil
 	}
 	p := unsafe.Pointer(&e.bytes[0])

--- a/internal/clip/clip.go
+++ b/internal/clip/clip.go
@@ -29,6 +29,19 @@ func DotProductFloat32Float(a []float32, b []Float) (float32, error) {
 	return dot, nil
 }
 
+func DotProductFloat32Float32(a []float32, b []float32) (float32, error) {
+	l := len(a)
+	if l != len(b) {
+		return 0, fmt.Errorf("slice lengths do not match, a %d b %d", l, len(b))
+	}
+
+	dot := float32(0)
+	for i := 0; i < l; i++ {
+		dot += a[i] * b[i]
+	}
+	return dot, nil
+}
+
 // Most real world inverse vector norms of embeddings fall
 // within ~500 of 11843, so it's more efficient to store
 // the inverse vector norm as an offset of this number.

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -101,6 +101,9 @@ func (g *Geo) String() string {
 	if g == nil || !g.config.ReverseGeocode {
 		return "geo reverse geocoding disabled"
 	}
+	if g.gp == nil {
+		return "geo geopackage not loaded"
+	}
 	return "geo using " + g.uri
 }
 

--- a/internal/layout/album.go
+++ b/internal/layout/album.go
@@ -37,13 +37,14 @@ func LayoutAlbumEvent(layout Layout, rect render.Rect, event *AlbumEvent, scene 
 				X: rect.X,
 				Y: rect.Y,
 				W: rect.W,
-				H: 30,
+				H: 40,
 			},
 			&font,
 			event.StartTime.Format(dateFormat),
 		)
+		text.VAlign = canvas.Bottom
 		scene.Texts = append(scene.Texts, text)
-		rect.Y += text.Sprite.Rect.H + 15
+		rect.Y += text.Sprite.Rect.H
 	}
 
 	font := scene.Fonts.Main.Face(50, canvas.Black, canvas.FontRegular, canvas.FontNormal)
@@ -53,21 +54,20 @@ func LayoutAlbumEvent(layout Layout, rect render.Rect, event *AlbumEvent, scene 
 			X: rect.X,
 			Y: rect.Y,
 			W: rect.W,
-			H: 30,
+			H: 40,
 		},
 		&font,
 		time,
 	)
+	text.VAlign = canvas.Bottom
 	scene.Texts = append(scene.Texts, text)
-	rect.Y += text.Sprite.Rect.H + 10
+	rect.Y += text.Sprite.Rect.H
 
 	newBounds := addSectionToScene(&event.Section, scene, rect, layout, source)
 
 	rect.Y = newBounds.Y + newBounds.H
 	if event.LastOnDay {
-		rect.Y += 40
-	} else {
-		rect.Y += 6
+		rect.Y += 32
 	}
 	return rect
 }

--- a/internal/layout/common.go
+++ b/internal/layout/common.go
@@ -17,13 +17,15 @@ import (
 type Type string
 
 const (
-	Album    Type = "ALBUM"
-	Timeline Type = "TIMELINE"
-	Square   Type = "SQUARE"
-	Wall     Type = "WALL"
-	Map      Type = "MAP"
-	Search   Type = "SEARCH"
-	Strip    Type = "STRIP"
+	Album      Type = "ALBUM"
+	Timeline   Type = "TIMELINE"
+	Square     Type = "SQUARE"
+	Wall       Type = "WALL"
+	Map        Type = "MAP"
+	Search     Type = "SEARCH"
+	Strip      Type = "STRIP"
+	Highlights Type = "HIGHLIGHTS"
+	Flex       Type = "FLEX"
 )
 
 type Order int

--- a/internal/layout/common.go
+++ b/internal/layout/common.go
@@ -103,6 +103,17 @@ type PhotoRegionData struct {
 	// SmallestThumbnail     string   `json:"smallest_thumbnail"`
 }
 
+func longestLine(s string) int {
+	lines := strings.Split(s, "\r")
+	longest := 0
+	for _, line := range lines {
+		if len(line) > longest {
+			longest = len(line)
+		}
+	}
+	return longest
+}
+
 func (regionSource PhotoRegionSource) getRegionFromPhoto(id int, photo *render.Photo, scene *render.Scene, regionConfig render.RegionConfig) render.Region {
 
 	source := regionSource.Source

--- a/internal/layout/dag/dag.go
+++ b/internal/layout/dag/dag.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Id = image.ImageId
+type Index = int
 
 type Photo struct {
 	Id          Id
@@ -16,62 +17,8 @@ type Aux struct {
 	Text string
 }
 
-type Index int
-
 type Node struct {
-	Index          Index
 	ShortestParent Index
 	Cost           float32
 	TotalAspect    float32
 }
-
-// type Graph[T Item] struct {
-// 	items []Item
-// 	q     *deque.Deque[Index]
-// 	nodes map[Index]Node
-// }
-
-// func New[T Item](items []Item) *Graph[T] {
-// 	g := &Graph[T]{
-// 		items: items,
-// 		q:     deque.New[Index](len(items) / 4),
-// 		nodes: make(map[Index]Node, len(items)),
-// 	}
-// 	g.nodes[-1] = Node{
-// 		ItemIndex:   -1,
-// 		Cost:        0,
-// 		TotalAspect: 0,
-// 	}
-// 	g.q.PushBack(0)
-// 	return g
-// }
-
-// func (g *Graph[T]) Next() Node {
-// 	idx := g.q.PopFront()
-// 	return g.nodes[idx]
-// }
-
-// func (g *Graph[T]) Add(i Index, cost float32) {
-// 	n, ok := g.nodes[i]
-// 	if ok {
-// 		if n.Cost > cost {
-// 			n.Cost = cost
-// 			n.ShortestParent = i
-// 			// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
-// 		}
-// 		// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
-// 		// }
-// 	} else {
-// 		n = &FlexNode{
-// 			Index:       i,
-// 			Cost:        totalCost,
-// 			TotalAspect: float32(totalAspect),
-// 			Shortest:    node,
-// 		}
-// 		indexToNode[i] = n
-// 		if i < len(photos)-1 {
-// 			q.PushBack(n)
-// 		}
-// 		// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
-// 	}
-// }

--- a/internal/layout/dag/dag.go
+++ b/internal/layout/dag/dag.go
@@ -1,0 +1,77 @@
+package dag
+
+import (
+	"photofield/internal/image"
+)
+
+type Id = image.ImageId
+
+type Photo struct {
+	Id          Id
+	AspectRatio float32
+	Aux         bool
+}
+
+type Aux struct {
+	Text string
+}
+
+type Index int
+
+type Node struct {
+	Index          Index
+	ShortestParent Index
+	Cost           float32
+	TotalAspect    float32
+}
+
+// type Graph[T Item] struct {
+// 	items []Item
+// 	q     *deque.Deque[Index]
+// 	nodes map[Index]Node
+// }
+
+// func New[T Item](items []Item) *Graph[T] {
+// 	g := &Graph[T]{
+// 		items: items,
+// 		q:     deque.New[Index](len(items) / 4),
+// 		nodes: make(map[Index]Node, len(items)),
+// 	}
+// 	g.nodes[-1] = Node{
+// 		ItemIndex:   -1,
+// 		Cost:        0,
+// 		TotalAspect: 0,
+// 	}
+// 	g.q.PushBack(0)
+// 	return g
+// }
+
+// func (g *Graph[T]) Next() Node {
+// 	idx := g.q.PopFront()
+// 	return g.nodes[idx]
+// }
+
+// func (g *Graph[T]) Add(i Index, cost float32) {
+// 	n, ok := g.nodes[i]
+// 	if ok {
+// 		if n.Cost > cost {
+// 			n.Cost = cost
+// 			n.ShortestParent = i
+// 			// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
+// 		}
+// 		// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
+// 		// }
+// 	} else {
+// 		n = &FlexNode{
+// 			Index:       i,
+// 			Cost:        totalCost,
+// 			TotalAspect: float32(totalAspect),
+// 			Shortest:    node,
+// 		}
+// 		indexToNode[i] = n
+// 		if i < len(photos)-1 {
+// 			q.PushBack(n)
+// 		}
+// 		// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
+// 	}
+// }

--- a/internal/layout/flex.go
+++ b/internal/layout/flex.go
@@ -1,0 +1,333 @@
+package layout
+
+import (
+	// . "photofield/internal"
+
+	"fmt"
+	"math"
+	"photofield/internal/image"
+	"photofield/internal/render"
+	"time"
+)
+
+type FlexPhoto struct {
+	Id          image.ImageId
+	AspectRatio float64
+}
+
+type FlexNode struct {
+	Index       int
+	Cost        float64
+	ImageHeight float64
+	TotalAspect float64
+	Links       []*FlexNode
+	Shortest    *FlexNode
+}
+
+// func (n *FlexNode) Dot() string {
+// 	// dot := ""
+// 	dot := fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\"];\n", n.Index, n.Index, n.Cost, n.ImageHeight)
+// 	for _, link := range n.Links {
+// 		dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
+// 		// dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
+// 		dot += link.Dot()
+// 	}
+// 	return dot
+// }
+
+func (n *FlexNode) Dot() string {
+	// dot := ""
+
+	stack := []*FlexNode{n}
+	visited := make(map[int]bool)
+	dot := ""
+	for len(stack) > 0 {
+		node := stack[0]
+		stack = stack[1:]
+		if visited[node.Index] {
+			continue
+		}
+		visited[node.Index] = true
+		dot += fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\\nTotalAspect: %.2f\"];\n", node.Index, node.Index, node.Cost, node.ImageHeight, node.TotalAspect)
+		for _, link := range node.Links {
+			attr := ""
+			if link.Shortest == node {
+				attr = " [penwidth=3]"
+			}
+			dot += fmt.Sprintf("\t%d -> %d%s;\n", node.Index, link.Index, attr)
+			stack = append(stack, link)
+		}
+	}
+
+	// dot := fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\"];\n", n.Index, n.Index, n.Cost, n.ImageHeight)
+	// for _, link := range n.Links {
+	// 	dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
+	// 	// dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
+	// 	dot += link.Dot()
+	// }
+	return dot
+}
+
+func LayoutFlex(infos <-chan image.SourcedInfo, layout Layout, scene *render.Scene, source *image.Source) {
+
+	layout.ImageSpacing = 0.02 * layout.ImageHeight
+	layout.LineSpacing = 0.02 * layout.ImageHeight
+
+	sceneMargin := 10.
+
+	scene.Bounds.W = layout.ViewportWidth
+
+	rect := render.Rect{
+		X: sceneMargin,
+		Y: sceneMargin + 64,
+		W: scene.Bounds.W - sceneMargin*2,
+		H: 0,
+	}
+
+	// section := Section{}
+
+	scene.Solids = make([]render.Solid, 0)
+	scene.Texts = make([]render.Text, 0)
+
+	// layoutPlaced := metrics.Elapsed("layout placing")
+	// layoutCounter := metrics.Counter{
+	// 	Name:     "layout",
+	// 	Interval: 1 * time.Second,
+	// }
+
+	// row := make([]SectionPhoto, 0)
+
+	// x := 0.
+	// y := 0.
+
+	idealHeight := layout.ImageHeight
+	minHeight := 0.8 * idealHeight
+	maxHeight := 1.2 * idealHeight
+
+	// baseWidth := layout.ViewportWidth * 0.29
+
+	photos := make([]FlexPhoto, 0)
+
+	for info := range infos {
+		photo := FlexPhoto{
+			Id:          info.Id,
+			AspectRatio: float64(info.Width) / float64(info.Height),
+		}
+		photos = append(photos, photo)
+	}
+
+	for startTime := time.Now(); time.Since(startTime) < 10*time.Second; {
+
+		scene.Photos = scene.Photos[:0]
+		root := &FlexNode{
+			Index:       -1,
+			Cost:        0,
+			Links:       nil,
+			TotalAspect: 0,
+		}
+		stack := []*FlexNode{root}
+		indexToNode := make(map[int]*FlexNode)
+
+		maxLineWidth := rect.W
+
+		for len(stack) > 0 {
+			node := stack[0]
+			stack = stack[1:]
+
+			totalAspect := 0.
+
+			// fmt.Printf("stack %d\n", node.Index)
+
+			for i := node.Index + 1; i < len(photos); i++ {
+				photo := photos[i]
+				totalAspect += photo.AspectRatio
+				totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
+				photoHeight := (maxLineWidth - totalSpacing) / totalAspect
+				valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1
+				badness := math.Abs(photoHeight - idealHeight)
+				cost := badness*badness + 10
+				// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
+				// Handle edge case where there is no other option
+				// but to accept a photo that would otherwise break outside of the desired size
+				if photoHeight < minHeight && len(stack) == 0 {
+					valid = true
+				}
+				if valid {
+					n, ok := indexToNode[i]
+					totalCost := node.Cost + cost
+					if ok {
+						if n.Cost > totalCost {
+							n.Cost = totalCost
+							n.TotalAspect = totalAspect
+							n.Shortest = node
+							// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
+						} else {
+							// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
+						}
+					} else {
+						n = &FlexNode{
+							Index:       i,
+							Cost:        totalCost,
+							ImageHeight: photoHeight,
+							Links:       nil,
+							TotalAspect: totalAspect,
+							Shortest:    node,
+						}
+						indexToNode[i] = n
+						if i < len(photos)-1 {
+							stack = append(stack, n)
+						}
+						// fmt.Printf("  node %d added with cost %f total aspect %f\n", i, n.Cost, n.TotalAspect)
+					}
+					node.Links = append(node.Links, n)
+				}
+				if photoHeight < minHeight {
+					break
+				} else if photoHeight > maxHeight {
+					continue
+				}
+			}
+		}
+
+		// dot := "digraph NodeGraph {\n"
+		// dot += root.Dot()
+		// dot += "}"
+		// fmt.Println(dot)
+
+		// fmt.Printf("photos %d\n", len(photos))
+
+		shortestPath := make([]*FlexNode, 0)
+		for node := indexToNode[len(photos)-1]; node != nil; {
+			// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
+			shortestPath = append(shortestPath, node)
+			node = node.Shortest
+		}
+
+		// fmt.Printf("max line width %f\n", maxLineWidth)
+		x := 0.
+		y := 0.
+		idx := 0
+		for i := len(shortestPath) - 2; i >= 0; i-- {
+			node := shortestPath[i]
+			prev := shortestPath[i+1]
+			totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
+			imageHeight := (maxLineWidth - totalSpacing) / node.TotalAspect
+			// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
+			for ; idx <= node.Index; idx++ {
+				photo := photos[idx]
+				imageWidth := imageHeight * photo.AspectRatio
+				scene.Photos = append(scene.Photos, render.Photo{
+					Id: photo.Id,
+					Sprite: render.Sprite{
+						Rect: render.Rect{
+							X: rect.X + x,
+							Y: rect.Y + y,
+							W: imageWidth,
+							H: imageHeight,
+						},
+					},
+				})
+				x += imageWidth + layout.ImageSpacing
+				// fmt.Printf("photo %d aspect %f\n", idx, photo.AspectRatio)
+			}
+			x = 0
+			y += imageHeight + layout.LineSpacing
+		}
+
+		// idx := 0
+		// for node := root; node != nil; {
+
+		// 	bestCost := math.MaxFloat64
+		// 	var bestNode *FlexNode
+		// 	for _, link := range node.Links {
+		// 		if link.Cost < bestCost {
+		// 			bestCost = link.Cost
+		// 			bestNode = link
+		// 		}
+		// 	}
+		// 	node = bestNode
+		// 	if node == nil {
+		// 		break
+		// 	}
+		// 	imageHeight := maxLineWidth / node.TotalAspect
+		// 	fmt.Printf("node %d cost %f total aspect %f height %f\n", node.Index, node.Cost, node.TotalAspect, imageHeight)
+		// 	for ; idx <= node.Index; idx++ {
+		// 		photo := photos[idx]
+		// 		imageWidth := imageHeight * photo.AspectRatio
+		// 		scene.Photos = append(scene.Photos, render.Photo{
+		// 			Id: photo.Id,
+		// 			Sprite: render.Sprite{
+		// 				Rect: render.Rect{
+		// 					X: rect.X + x,
+		// 					Y: rect.Y + y,
+		// 					W: imageWidth,
+		// 					H: imageHeight,
+		// 				},
+		// 			},
+		// 		})
+		// 		x += imageWidth
+		// 		fmt.Printf("photo %d aspect %f\n", idx, photo.AspectRatio)
+		// 	}
+		// 	x = 0
+		// 	y += imageHeight
+		// }
+
+		// index := 0
+		// for info := range infos {
+		// 	photo := SectionPhoto{
+		// 		Photo: render.Photo{
+		// 			Id:     info.Id,
+		// 			Sprite: render.Sprite{},
+		// 		},
+		// 		Size: image.Size{
+		// 			X: info.Width,
+		// 			Y: info.Height,
+		// 		},
+		// 	}
+
+		// 	imageWidth := baseWidth
+		// 	// section.infos = append(section.infos, info.SourcedInfo)
+
+		// 	if x+imageWidth > rect.W {
+		// 		for _, p := range row {
+		// 			scene.Photos = append(scene.Photos, p.Photo)
+		// 		}
+		// 		row = nil
+		// 		x = 0
+		// 		y += layout.ImageHeight + layout.LineSpacing
+		// 	}
+
+		// 	photo.Photo.Sprite.PlaceFitWidth(
+		// 		rect.X+x,
+		// 		rect.Y+y,
+		// 		imageWidth,
+		// 		float64(photo.Size.X),
+		// 		float64(photo.Size.Y),
+		// 	)
+
+		// 	row = append(row, photo)
+
+		// 	x += imageWidth + layout.ImageSpacing
+
+		// 	layoutCounter.Set(index)
+		// 	index++
+		// 	scene.FileCount = index
+		// }
+		// for _, p := range row {
+		// 	scene.Photos = append(scene.Photos, p.Photo)
+		// }
+		// x = 0
+		// y += layout.ImageHeight + layout.LineSpacing
+
+		// rect.Y = y
+
+		// newBounds := addSectionToScene(&section, scene, rect, layout, source)
+		// layoutPlaced()
+
+		scene.Bounds.H = rect.Y + y + sceneMargin
+	}
+
+	scene.RegionSource = PhotoRegionSource{
+		Source: source,
+	}
+}

--- a/internal/layout/flex.go
+++ b/internal/layout/flex.go
@@ -96,6 +96,10 @@ func LayoutFlex(infos <-chan image.SourcedInfo, layout Layout, scene *render.Sce
 				}
 			}
 		}
+		if info.Width == 0 || info.Height == 0 {
+			info.Width = 3
+			info.Height = 2
+		}
 		photo := dag.Photo{
 			Id:          info.Id,
 			AspectRatio: float32(info.Width) / float32(info.Height),

--- a/internal/layout/flex.go
+++ b/internal/layout/flex.go
@@ -3,37 +3,34 @@ package layout
 import (
 	// . "photofield/internal"
 
-	"fmt"
+	"context"
 	"math"
 	"photofield/internal/image"
+	"photofield/internal/metrics"
 	"photofield/internal/render"
 	"time"
+
+	"github.com/gammazero/deque"
+	"github.com/golang/geo/s2"
+	"github.com/tdewolff/canvas"
 )
 
 type FlexPhoto struct {
 	Id          image.ImageId
-	AspectRatio float64
+	AspectRatio float32
+	Aux         bool
+}
+
+type FlexAux struct {
+	Text string
 }
 
 type FlexNode struct {
 	Index       int
-	Cost        float64
-	ImageHeight float64
-	TotalAspect float64
-	Links       []*FlexNode
+	Cost        float32
+	TotalAspect float32
 	Shortest    *FlexNode
 }
-
-// func (n *FlexNode) Dot() string {
-// 	// dot := ""
-// 	dot := fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\"];\n", n.Index, n.Index, n.Cost, n.ImageHeight)
-// 	for _, link := range n.Links {
-// 		dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
-// 		// dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
-// 		dot += link.Dot()
-// 	}
-// 	return dot
-// }
 
 func (n *FlexNode) Dot() string {
 	// dot := ""
@@ -48,23 +45,16 @@ func (n *FlexNode) Dot() string {
 			continue
 		}
 		visited[node.Index] = true
-		dot += fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\\nTotalAspect: %.2f\"];\n", node.Index, node.Index, node.Cost, node.ImageHeight, node.TotalAspect)
-		for _, link := range node.Links {
-			attr := ""
-			if link.Shortest == node {
-				attr = " [penwidth=3]"
-			}
-			dot += fmt.Sprintf("\t%d -> %d%s;\n", node.Index, link.Index, attr)
-			stack = append(stack, link)
-		}
+		// dot += fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\\nTotalAspect: %.2f\"];\n", node.Index, node.Index, node.Cost, node.ImageHeight, node.TotalAspect)
+		// for _, link := range node.Links {
+		// 	attr := ""
+		// 	if link.Shortest == node {
+		// 		attr = " [penwidth=3]"
+		// 	}
+		// 	dot += fmt.Sprintf("\t%d -> %d%s;\n", node.Index, link.Index, attr)
+		// 	stack = append(stack, link)
+		// }
 	}
-
-	// dot := fmt.Sprintf("%d [label=\"%d\\nCost: %.0f\\nHeight: %.0f\"];\n", n.Index, n.Index, n.Cost, n.ImageHeight)
-	// for _, link := range n.Links {
-	// 	dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
-	// 	// dot += fmt.Sprintf("\t%d -> %d;\n", n.Index, link.Index)
-	// 	dot += link.Dot()
-	// }
 	return dot
 }
 
@@ -84,16 +74,10 @@ func LayoutFlex(infos <-chan image.SourcedInfo, layout Layout, scene *render.Sce
 		H: 0,
 	}
 
-	// section := Section{}
-
 	scene.Solids = make([]render.Solid, 0)
 	scene.Texts = make([]render.Text, 0)
 
-	// layoutPlaced := metrics.Elapsed("layout placing")
-	// layoutCounter := metrics.Counter{
-	// 	Name:     "layout",
-	// 	Interval: 1 * time.Second,
-	// }
+	layoutPlaced := metrics.Elapsed("layout placing")
 
 	// row := make([]SectionPhoto, 0)
 
@@ -106,116 +90,180 @@ func LayoutFlex(infos <-chan image.SourcedInfo, layout Layout, scene *render.Sce
 
 	// baseWidth := layout.ViewportWidth * 0.29
 
+	scene.Photos = scene.Photos[:0]
 	photos := make([]FlexPhoto, 0)
 
-	for info := range infos {
-		photo := FlexPhoto{
-			Id:          info.Id,
-			AspectRatio: float64(info.Width) / float64(info.Height),
-		}
-		photos = append(photos, photo)
+	layoutCounter := metrics.Counter{
+		Name:     "layout",
+		Interval: 1 * time.Second,
 	}
 
-	for startTime := time.Now(); time.Since(startTime) < 10*time.Second; {
+	auxs := make([]FlexAux, 0)
 
-		scene.Photos = scene.Photos[:0]
-		root := &FlexNode{
-			Index:       -1,
-			Cost:        0,
-			Links:       nil,
-			TotalAspect: 0,
-		}
-		stack := []*FlexNode{root}
-		indexToNode := make(map[int]*FlexNode)
-
-		maxLineWidth := rect.W
-
-		for len(stack) > 0 {
-			node := stack[0]
-			stack = stack[1:]
-
-			totalAspect := 0.
-
-			// fmt.Printf("stack %d\n", node.Index)
-
-			for i := node.Index + 1; i < len(photos); i++ {
-				photo := photos[i]
-				totalAspect += photo.AspectRatio
-				totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
-				photoHeight := (maxLineWidth - totalSpacing) / totalAspect
-				valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1
-				badness := math.Abs(photoHeight - idealHeight)
-				cost := badness*badness + 10
-				// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
-				// Handle edge case where there is no other option
-				// but to accept a photo that would otherwise break outside of the desired size
-				if photoHeight < minHeight && len(stack) == 0 {
-					valid = true
-				}
-				if valid {
-					n, ok := indexToNode[i]
-					totalCost := node.Cost + cost
-					if ok {
-						if n.Cost > totalCost {
-							n.Cost = totalCost
-							n.TotalAspect = totalAspect
-							n.Shortest = node
-							// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
-						} else {
-							// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
+	// Fetch all photos
+	var lastLoc s2.LatLng
+	var lastLocTime time.Time
+	var lastLocation string
+	for info := range infos {
+		if source.Geo.Available() {
+			photoTime := info.DateTime
+			lastLocCheck := lastLocTime.Sub(photoTime)
+			if lastLocCheck < 0 {
+				lastLocCheck = -lastLocCheck
+			}
+			queryLocation := lastLocTime.IsZero() || lastLocCheck > 15*time.Minute
+			// fmt.Printf("lastLocTime %v photoTime %v lastLocCheck %v queryLocation %v\n", lastLocTime, photoTime, lastLocCheck, queryLocation)
+			if queryLocation && image.IsValidLatLng(info.LatLng) {
+				lastLocTime = photoTime
+				dist := image.AngleToKm(lastLoc.Distance(info.LatLng))
+				if dist > 1 {
+					location, err := source.Geo.ReverseGeocode(context.TODO(), info.LatLng)
+					if err == nil && location != lastLocation {
+						lastLocation = location
+						aux := FlexAux{
+							Text: location,
 						}
-					} else {
-						n = &FlexNode{
-							Index:       i,
-							Cost:        totalCost,
-							ImageHeight: photoHeight,
-							Links:       nil,
-							TotalAspect: totalAspect,
-							Shortest:    node,
-						}
-						indexToNode[i] = n
-						if i < len(photos)-1 {
-							stack = append(stack, n)
-						}
-						// fmt.Printf("  node %d added with cost %f total aspect %f\n", i, n.Cost, n.TotalAspect)
+						auxs = append(auxs, aux)
+						photos = append(photos, FlexPhoto{
+							Id:          image.ImageId(len(auxs) - 1),
+							AspectRatio: float32(len(location)) / 5,
+							Aux:         true,
+						})
 					}
-					node.Links = append(node.Links, n)
-				}
-				if photoHeight < minHeight {
-					break
-				} else if photoHeight > maxHeight {
-					continue
+					lastLoc = info.LatLng
 				}
 			}
 		}
-
-		// dot := "digraph NodeGraph {\n"
-		// dot += root.Dot()
-		// dot += "}"
-		// fmt.Println(dot)
-
-		// fmt.Printf("photos %d\n", len(photos))
-
-		shortestPath := make([]*FlexNode, 0)
-		for node := indexToNode[len(photos)-1]; node != nil; {
-			// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
-			shortestPath = append(shortestPath, node)
-			node = node.Shortest
+		photo := FlexPhoto{
+			Id:          info.Id,
+			AspectRatio: float32(info.Width) / float32(info.Height),
 		}
+		photos = append(photos, photo)
+		layoutCounter.Set(len(photos))
+	}
 
-		// fmt.Printf("max line width %f\n", maxLineWidth)
-		x := 0.
-		y := 0.
-		idx := 0
-		for i := len(shortestPath) - 2; i >= 0; i-- {
-			node := shortestPath[i]
-			prev := shortestPath[i+1]
-			totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
-			imageHeight := (maxLineWidth - totalSpacing) / node.TotalAspect
-			// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
-			for ; idx <= node.Index; idx++ {
-				photo := photos[idx]
-				imageWidth := imageHeight * photo.AspectRatio
+	root := &FlexNode{
+		Index:       -1,
+		Cost:        0,
+		TotalAspect: 0,
+	}
+
+	q := deque.New[*FlexNode](len(photos) / 4)
+	q.PushBack(root)
+	indexToNode := make(map[int]*FlexNode, len(photos))
+
+	maxLineWidth := rect.W
+
+	for q.Len() > 0 {
+		node := q.PopFront()
+		totalAspect := 0.
+		fallback := false
+
+		// fmt.Printf("queue %d\n", node.Index)
+		for i := node.Index + 1; i < len(photos); i++ {
+			photo := photos[i]
+			totalAspect += float64(photo.AspectRatio)
+			totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
+			photoHeight := (maxLineWidth - totalSpacing) / totalAspect
+			valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
+			badness := math.Abs(photoHeight - idealHeight)
+			cost := badness*badness + 10
+			if i < len(photos)-1 && photos[i+1].Aux {
+				cost *= 0.1
+			}
+
+			// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
+
+			// Handle edge case where there is no other option
+			// but to accept a photo that would otherwise break outside of the desired size
+			// if i != len(photos)-1 && q.Len() == 0 {
+			// 	valid = true
+			// }
+			if valid {
+				n, ok := indexToNode[i]
+				totalCost := node.Cost + float32(cost)
+				if ok {
+					if n.Cost > totalCost {
+						n.Cost = totalCost
+						n.TotalAspect = float32(totalAspect)
+						n.Shortest = node
+						// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
+					}
+					// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
+					// }
+				} else {
+					n = &FlexNode{
+						Index:       i,
+						Cost:        totalCost,
+						TotalAspect: float32(totalAspect),
+						Shortest:    node,
+					}
+					indexToNode[i] = n
+					if i < len(photos)-1 {
+						q.PushBack(n)
+					}
+					// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
+				}
+				// fmt.Printf("  node %d %v cost %f\n", i, ok, n.Cost)
+			}
+			if photoHeight < minHeight {
+				// Handle edge case where there is no other option
+				// but to accept a photo that would otherwise break outside of the desired size
+				if !fallback && i != len(photos)-1 && q.Len() == 0 {
+					fallback = true
+					for j := 0; j < 2 && i > node.Index; j++ {
+						// fmt.Printf("  fallback %d\n", i)
+						totalAspect -= float64(photos[i].AspectRatio)
+						i--
+					}
+					continue
+				}
+				break
+			}
+		}
+	}
+
+	// dot := "digraph NodeGraph {\n"
+	// dot += root.Dot()
+	// dot += "}"
+	// fmt.Println(dot)
+
+	// Trace back the shortest path
+	shortestPath := make([]*FlexNode, 0)
+	for node := indexToNode[len(photos)-1]; node != nil; {
+		// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
+		shortestPath = append(shortestPath, node)
+		node = node.Shortest
+	}
+
+	// Finally, place the photos based on the shortest path breaks
+	x := 0.
+	y := 0.
+	idx := 0
+	for i := len(shortestPath) - 2; i >= 0; i-- {
+		node := shortestPath[i]
+		prev := shortestPath[i+1]
+		totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
+		imageHeight := (maxLineWidth - totalSpacing) / float64(node.TotalAspect)
+		// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
+		for ; idx <= node.Index; idx++ {
+			photo := photos[idx]
+			imageWidth := imageHeight * float64(photo.AspectRatio)
+			if photo.Aux {
+				aux := auxs[photo.Id]
+				font := scene.Fonts.Main.Face(imageHeight*0.6, canvas.Dimgray, canvas.FontRegular, canvas.FontNormal)
+				text := render.NewTextFromRect(
+					render.Rect{
+						X: rect.X + x + imageWidth*0.01,
+						Y: rect.Y + y - imageHeight*0.1,
+						W: imageWidth,
+						H: imageHeight,
+					},
+					&font,
+					aux.Text,
+				)
+				scene.Texts = append(scene.Texts, text)
+			} else {
 				scene.Photos = append(scene.Photos, render.Photo{
 					Id: photo.Id,
 					Sprite: render.Sprite{
@@ -227,105 +275,20 @@ func LayoutFlex(infos <-chan image.SourcedInfo, layout Layout, scene *render.Sce
 						},
 					},
 				})
-				x += imageWidth + layout.ImageSpacing
-				// fmt.Printf("photo %d aspect %f\n", idx, photo.AspectRatio)
 			}
-			x = 0
-			y += imageHeight + layout.LineSpacing
+			x += imageWidth + layout.ImageSpacing
+			// fmt.Printf("photo %d x %4.0f y %4.0f aspect %f height %f\n", idx, rect.X+x, rect.Y+y, photo.AspectRatio, imageHeight)
 		}
-
-		// idx := 0
-		// for node := root; node != nil; {
-
-		// 	bestCost := math.MaxFloat64
-		// 	var bestNode *FlexNode
-		// 	for _, link := range node.Links {
-		// 		if link.Cost < bestCost {
-		// 			bestCost = link.Cost
-		// 			bestNode = link
-		// 		}
-		// 	}
-		// 	node = bestNode
-		// 	if node == nil {
-		// 		break
-		// 	}
-		// 	imageHeight := maxLineWidth / node.TotalAspect
-		// 	fmt.Printf("node %d cost %f total aspect %f height %f\n", node.Index, node.Cost, node.TotalAspect, imageHeight)
-		// 	for ; idx <= node.Index; idx++ {
-		// 		photo := photos[idx]
-		// 		imageWidth := imageHeight * photo.AspectRatio
-		// 		scene.Photos = append(scene.Photos, render.Photo{
-		// 			Id: photo.Id,
-		// 			Sprite: render.Sprite{
-		// 				Rect: render.Rect{
-		// 					X: rect.X + x,
-		// 					Y: rect.Y + y,
-		// 					W: imageWidth,
-		// 					H: imageHeight,
-		// 				},
-		// 			},
-		// 		})
-		// 		x += imageWidth
-		// 		fmt.Printf("photo %d aspect %f\n", idx, photo.AspectRatio)
-		// 	}
-		// 	x = 0
-		// 	y += imageHeight
-		// }
-
-		// index := 0
-		// for info := range infos {
-		// 	photo := SectionPhoto{
-		// 		Photo: render.Photo{
-		// 			Id:     info.Id,
-		// 			Sprite: render.Sprite{},
-		// 		},
-		// 		Size: image.Size{
-		// 			X: info.Width,
-		// 			Y: info.Height,
-		// 		},
-		// 	}
-
-		// 	imageWidth := baseWidth
-		// 	// section.infos = append(section.infos, info.SourcedInfo)
-
-		// 	if x+imageWidth > rect.W {
-		// 		for _, p := range row {
-		// 			scene.Photos = append(scene.Photos, p.Photo)
-		// 		}
-		// 		row = nil
-		// 		x = 0
-		// 		y += layout.ImageHeight + layout.LineSpacing
-		// 	}
-
-		// 	photo.Photo.Sprite.PlaceFitWidth(
-		// 		rect.X+x,
-		// 		rect.Y+y,
-		// 		imageWidth,
-		// 		float64(photo.Size.X),
-		// 		float64(photo.Size.Y),
-		// 	)
-
-		// 	row = append(row, photo)
-
-		// 	x += imageWidth + layout.ImageSpacing
-
-		// 	layoutCounter.Set(index)
-		// 	index++
-		// 	scene.FileCount = index
-		// }
-		// for _, p := range row {
-		// 	scene.Photos = append(scene.Photos, p.Photo)
-		// }
-		// x = 0
-		// y += layout.ImageHeight + layout.LineSpacing
-
-		// rect.Y = y
-
-		// newBounds := addSectionToScene(&section, scene, rect, layout, source)
-		// layoutPlaced()
-
-		scene.Bounds.H = rect.Y + y + sceneMargin
+		x = 0
+		y += imageHeight + layout.LineSpacing
 	}
+
+	// fmt.Printf("photos %d indextonode %d stack %d\n", len(photos), len(indexToNode), q.Len())
+	// fmt.Printf("photos %d stack %d\n", cap(photos), q.Cap())
+
+	rect.H = rect.Y + y + sceneMargin - layout.LineSpacing
+	scene.Bounds.H = rect.H
+	layoutPlaced()
 
 	scene.RegionSource = PhotoRegionSource{
 		Source: source,

--- a/internal/layout/highlights.go
+++ b/internal/layout/highlights.go
@@ -3,7 +3,6 @@ package layout
 import (
 	// . "photofield/internal"
 
-	"context"
 	"log"
 	"math"
 	"photofield/internal/clip"
@@ -13,10 +12,6 @@ import (
 	"strings"
 
 	"time"
-
-	"github.com/gammazero/deque"
-	"github.com/golang/geo/s2"
-	"github.com/tdewolff/canvas"
 )
 
 type HighlightPhoto struct {
@@ -37,300 +32,300 @@ func longestLine(s string) int {
 
 func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.Scene, source *image.Source) {
 
-	layout.ImageSpacing = math.Min(2, 0.02*layout.ImageHeight)
-	layout.LineSpacing = layout.ImageSpacing
+	// layout.ImageSpacing = math.Min(2, 0.02*layout.ImageHeight)
+	// layout.LineSpacing = layout.ImageSpacing
 
-	sceneMargin := 10.
+	// sceneMargin := 10.
 
-	scene.Bounds.W = layout.ViewportWidth
+	// scene.Bounds.W = layout.ViewportWidth
 
-	rect := render.Rect{
-		X: sceneMargin,
-		Y: sceneMargin + 64,
-		W: scene.Bounds.W - sceneMargin*2,
-		H: 0,
-	}
+	// rect := render.Rect{
+	// 	X: sceneMargin,
+	// 	Y: sceneMargin + 64,
+	// 	W: scene.Bounds.W - sceneMargin*2,
+	// 	H: 0,
+	// }
 
-	scene.Solids = make([]render.Solid, 0)
-	scene.Texts = make([]render.Text, 0)
+	// scene.Solids = make([]render.Solid, 0)
+	// scene.Texts = make([]render.Text, 0)
 
-	layoutPlaced := metrics.Elapsed("layout placing")
+	// layoutPlaced := metrics.Elapsed("layout placing")
 
-	// row := make([]SectionPhoto, 0)
+	// // row := make([]SectionPhoto, 0)
 
+	// // x := 0.
+	// // y := 0.
+
+	// idealHeight := math.Min(layout.ImageHeight, layout.ViewportHeight*0.9)
+	// minHeightFrac := 0.05
+	// auxHeight := math.Max(80, idealHeight)
+	// minAuxHeight := auxHeight * 0.8
+	// simMin := 0.6
+	// // simPow := 3.3
+	// // simPow := 0.7
+	// // simPow := 0.3
+	// // simPow := 1.8
+	// simPow := 1.5
+	// // simPow := 0.5
+
+	// // baseWidth := layout.ViewportWidth * 0.29
+
+	// // Gather all photos
+	// scene.Photos = scene.Photos[:0]
+	// photos := make([]HighlightPhoto, 0)
+	// var prevEmb []float32
+	// var prevInvNorm float32
+	// var prevLoc s2.LatLng
+	// var prevLocTime time.Time
+	// var prevLocation string
+	// var prevAuxTime time.Time
+	// layoutCounter := metrics.Counter{
+	// 	Name:     "layout",
+	// 	Interval: 1 * time.Second,
+	// }
+	// auxs := make([]FlexAux, 0)
+	// for info := range infos {
+
+	// 	if source.Geo.Available() {
+	// 		photoTime := info.DateTime
+	// 		lastLocCheck := prevLocTime.Sub(photoTime)
+	// 		if lastLocCheck < 0 {
+	// 			lastLocCheck = -lastLocCheck
+	// 		}
+	// 		queryLocation := prevLocTime.IsZero() || lastLocCheck > 15*time.Minute
+	// 		// fmt.Printf("lastLocTime %v photoTime %v lastLocCheck %v queryLocation %v\n", lastLocTime, photoTime, lastLocCheck, queryLocation)
+	// 		if queryLocation && image.IsValidLatLng(info.LatLng) {
+	// 			prevLocTime = photoTime
+	// 			dist := image.AngleToKm(prevLoc.Distance(info.LatLng))
+	// 			if dist > 1 {
+	// 				location, err := source.Geo.ReverseGeocode(context.TODO(), info.LatLng)
+	// 				if err == nil && location != prevLocation {
+	// 					prevLocation = location
+	// 					text := ""
+	// 					if prevAuxTime.Year() != photoTime.Year() {
+	// 						text += photoTime.Format("2006\r")
+	// 					}
+	// 					if prevAuxTime.YearDay() != photoTime.YearDay() {
+	// 						text += photoTime.Format("Jan 2\rMonday\r")
+	// 					}
+	// 					prevAuxTime = photoTime
+	// 					text += location
+	// 					aux := FlexAux{
+	// 						Text: text,
+	// 					}
+	// 					auxs = append(auxs, aux)
+	// 					photos = append(photos, HighlightPhoto{
+	// 						FlexPhoto: FlexPhoto{
+	// 							Id:          image.ImageId(len(auxs) - 1),
+	// 							AspectRatio: 0.2 + float32(longestLine(text))/10,
+	// 							Aux:         true,
+	// 						},
+	// 						Height: float32(auxHeight),
+	// 					})
+	// 				}
+	// 				prevLoc = info.LatLng
+	// 			}
+	// 		}
+	// 	}
+
+	// 	similarity := float32(0.)
+	// 	emb := info.Embedding.Float32()
+	// 	invnorm := info.Embedding.InvNormFloat32()
+	// 	simHeight := idealHeight
+	// 	if prevEmb != nil {
+	// 		dot, err := clip.DotProductFloat32Float32(
+	// 			prevEmb,
+	// 			emb,
+	// 		)
+	// 		if err != nil {
+	// 			log.Printf("dot product error: %v", err)
+	// 		}
+	// 		similarity = dot * prevInvNorm * invnorm
+	// 		simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
+	// 	}
+	// 	prevEmb = emb
+	// 	prevInvNorm = invnorm
+
+	// 	photo := HighlightPhoto{
+	// 		FlexPhoto: FlexPhoto{
+	// 			Id:          info.Id,
+	// 			AspectRatio: float32(info.Width) / float32(info.Height),
+	// 		},
+	// 		Height: float32(simHeight),
+	// 	}
+	// 	photos = append(photos, photo)
+	// 	layoutCounter.Set(len(photos))
+	// }
+
+	// root := &FlexNode{
+	// 	Index:       -1,
+	// 	Cost:        0,
+	// 	TotalAspect: 0,
+	// }
+
+	// q := deque.New[*FlexNode](len(photos) / 4)
+	// q.PushBack(root)
+	// indexToNode := make(map[int]*FlexNode, len(photos))
+
+	// maxLineWidth := rect.W
+	// for q.Len() > 0 {
+	// 	node := q.PopFront()
+	// 	totalAspect := 0.
+	// 	fallback := false
+	// 	hasAux := false
+
+	// 	// fmt.Printf("queue %d\n", node.Index)
+
+	// 	prevHeight := photos[0].Height
+
+	// 	for i := node.Index + 1; i < len(photos); i++ {
+	// 		photo := photos[i]
+	// 		totalAspect += float64(photo.AspectRatio)
+	// 		totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
+	// 		photoHeight := (maxLineWidth - totalSpacing) / totalAspect
+	// 		minHeight := 0.3 * float64(photo.Height)
+	// 		maxHeight := 1.7 * float64(photo.Height)
+	// 		valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
+	// 		// badness := math.Abs(photoHeight - idealHeight)
+	// 		badness := math.Abs(photoHeight - float64(photo.Height))
+	// 		prevDiff := 0.1 * math.Abs(float64(prevHeight-photo.Height))
+	// 		prevHeight = photo.Height
+	// 		// viewportDiff := 1000. * float64(photoHeight)
+	// 		viewportDiff := 1000. * math.Max(0, float64(photoHeight)-layout.ViewportHeight)
+	// 		cost := badness*badness + prevDiff*prevDiff + viewportDiff*viewportDiff + 10
+	// 		// Incentivise aux items to be placed at the beginning
+	// 		if i < len(photos)-1 && photos[i+1].Aux {
+	// 			cost -= 1000000
+	// 		}
+	// 		if hasAux && photoHeight < minAuxHeight {
+	// 			auxDiff := (minAuxHeight - photoHeight) * 4
+	// 			cost += auxDiff * auxDiff
+	// 		}
+	// 		if photo.Aux {
+	// 			hasAux = true
+	// 		}
+	// 		// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
+	// 		if valid {
+	// 			n, ok := indexToNode[i]
+	// 			totalCost := node.Cost + float32(cost)
+	// 			if ok {
+	// 				if n.Cost > totalCost {
+	// 					n.Cost = totalCost
+	// 					n.TotalAspect = float32(totalAspect)
+	// 					n.ShortestParent = node
+	// 					// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
+	// 				}
+	// 				// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
+	// 				// }
+	// 			} else {
+	// 				n = &FlexNode{
+	// 					Index:          i,
+	// 					Cost:           totalCost,
+	// 					TotalAspect:    float32(totalAspect),
+	// 					ShortestParent: node,
+	// 				}
+	// 				indexToNode[i] = n
+	// 				if i < len(photos)-1 {
+	// 					q.PushBack(n)
+	// 				}
+	// 				// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
+	// 			}
+	// 			// fmt.Printf("  node %d %v cost %f\n", i, ok, n.Cost)
+	// 		}
+	// 		if photoHeight < minHeight {
+	// 			// Handle edge case where there is no other option
+	// 			// but to accept a photo that would otherwise break outside of the desired size
+	// 			if !fallback && i != len(photos)-1 && q.Len() == 0 {
+	// 				fallback = true
+	// 				for j := 0; j < 2 && i-j > node.Index; j++ {
+	// 					totalAspect -= float64(photos[i-j].AspectRatio)
+	// 				}
+	// 				i = i - 2
+	// 				if i < node.Index+1 {
+	// 					i = node.Index + 1
+	// 				}
+	// 				continue
+	// 			}
+	// 			break
+	// 		}
+	// 	}
+	// }
+
+	// // dot := "digraph NodeGraph {\n"
+	// // dot += root.Dot()
+	// // dot += "}"
+	// // fmt.Println(dot)
+
+	// // Trace back the shortest path
+	// shortestPath := make([]*FlexNode, 0)
+	// for node := indexToNode[len(photos)-1]; node != nil; {
+	// 	// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
+	// 	shortestPath = append(shortestPath, node)
+	// 	node = node.ShortestParent
+	// }
+
+	// // Finally, place the photos based on the shortest path breaks
 	// x := 0.
 	// y := 0.
+	// idx := 0
+	// for i := len(shortestPath) - 2; i >= 0; i-- {
+	// 	node := shortestPath[i]
+	// 	prev := shortestPath[i+1]
+	// 	totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
+	// 	imageHeight := (maxLineWidth - totalSpacing) / float64(node.TotalAspect)
+	// 	// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
+	// 	for ; idx <= node.Index; idx++ {
+	// 		photo := photos[idx]
+	// 		imageWidth := imageHeight * float64(photo.AspectRatio)
 
-	idealHeight := math.Min(layout.ImageHeight, layout.ViewportHeight*0.9)
-	minHeightFrac := 0.05
-	auxHeight := math.Max(80, idealHeight)
-	minAuxHeight := auxHeight * 0.8
-	simMin := 0.6
-	// simPow := 3.3
-	// simPow := 0.7
-	// simPow := 0.3
-	// simPow := 1.8
-	simPow := 1.5
-	// simPow := 0.5
+	// 		if photo.Aux {
+	// 			aux := auxs[photo.Id]
+	// 			size := imageHeight * 0.5
+	// 			// lines := strings.Count(aux.Text, "\r") + 1
+	// 			font := scene.Fonts.Main.Face(size, canvas.Dimgray, canvas.FontRegular, canvas.FontNormal)
+	// 			// lineOffset := float64(lines-1) * size * 0.4
+	// 			padding := 2.
+	// 			text := render.Text{
+	// 				Sprite: render.Sprite{
+	// 					Rect: render.Rect{
+	// 						X: rect.X + x + padding,
+	// 						Y: rect.Y + y + padding,
+	// 						W: imageWidth - 2*padding,
+	// 						H: imageHeight - 2*padding,
+	// 					},
+	// 				},
+	// 				Font:   &font,
+	// 				Text:   aux.Text,
+	// 				HAlign: canvas.Left,
+	// 				VAlign: canvas.Bottom,
+	// 			}
+	// 			scene.Texts = append(scene.Texts, text)
+	// 		} else {
+	// 			scene.Photos = append(scene.Photos, render.Photo{
+	// 				Id: photo.Id,
+	// 				Sprite: render.Sprite{
+	// 					Rect: render.Rect{
+	// 						X: rect.X + x,
+	// 						Y: rect.Y + y,
+	// 						W: imageWidth,
+	// 						H: imageHeight,
+	// 					},
+	// 				},
+	// 			})
+	// 		}
+	// 		x += imageWidth + layout.ImageSpacing
+	// 		// fmt.Printf("photo %d aspect %f height %f\n", idx, photo.AspectRatio, photo.Height)
+	// 	}
+	// 	x = 0
+	// 	y += imageHeight + layout.LineSpacing
+	// }
 
-	// baseWidth := layout.ViewportWidth * 0.29
+	// // fmt.Printf("photos %d indextonode %d stack %d\n", len(photos), len(indexToNode), q.Len())
+	// // fmt.Printf("photos %d stack %d\n", cap(photos), q.Cap())
 
-	// Gather all photos
-	scene.Photos = scene.Photos[:0]
-	photos := make([]HighlightPhoto, 0)
-	var prevEmb []float32
-	var prevInvNorm float32
-	var prevLoc s2.LatLng
-	var prevLocTime time.Time
-	var prevLocation string
-	var prevAuxTime time.Time
-	layoutCounter := metrics.Counter{
-		Name:     "layout",
-		Interval: 1 * time.Second,
-	}
-	auxs := make([]FlexAux, 0)
-	for info := range infos {
-
-		if source.Geo.Available() {
-			photoTime := info.DateTime
-			lastLocCheck := prevLocTime.Sub(photoTime)
-			if lastLocCheck < 0 {
-				lastLocCheck = -lastLocCheck
-			}
-			queryLocation := prevLocTime.IsZero() || lastLocCheck > 15*time.Minute
-			// fmt.Printf("lastLocTime %v photoTime %v lastLocCheck %v queryLocation %v\n", lastLocTime, photoTime, lastLocCheck, queryLocation)
-			if queryLocation && image.IsValidLatLng(info.LatLng) {
-				prevLocTime = photoTime
-				dist := image.AngleToKm(prevLoc.Distance(info.LatLng))
-				if dist > 1 {
-					location, err := source.Geo.ReverseGeocode(context.TODO(), info.LatLng)
-					if err == nil && location != prevLocation {
-						prevLocation = location
-						text := ""
-						if prevAuxTime.Year() != photoTime.Year() {
-							text += photoTime.Format("2006\r")
-						}
-						if prevAuxTime.YearDay() != photoTime.YearDay() {
-							text += photoTime.Format("Jan 2\rMonday\r")
-						}
-						prevAuxTime = photoTime
-						text += location
-						aux := FlexAux{
-							Text: text,
-						}
-						auxs = append(auxs, aux)
-						photos = append(photos, HighlightPhoto{
-							FlexPhoto: FlexPhoto{
-								Id:          image.ImageId(len(auxs) - 1),
-								AspectRatio: 0.2 + float32(longestLine(text))/10,
-								Aux:         true,
-							},
-							Height: float32(auxHeight),
-						})
-					}
-					prevLoc = info.LatLng
-				}
-			}
-		}
-
-		similarity := float32(0.)
-		emb := info.Embedding.Float32()
-		invnorm := info.Embedding.InvNormFloat32()
-		simHeight := idealHeight
-		if prevEmb != nil {
-			dot, err := clip.DotProductFloat32Float32(
-				prevEmb,
-				emb,
-			)
-			if err != nil {
-				log.Printf("dot product error: %v", err)
-			}
-			similarity = dot * prevInvNorm * invnorm
-			simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
-		}
-		prevEmb = emb
-		prevInvNorm = invnorm
-
-		photo := HighlightPhoto{
-			FlexPhoto: FlexPhoto{
-				Id:          info.Id,
-				AspectRatio: float32(info.Width) / float32(info.Height),
-			},
-			Height: float32(simHeight),
-		}
-		photos = append(photos, photo)
-		layoutCounter.Set(len(photos))
-	}
-
-	root := &FlexNode{
-		Index:       -1,
-		Cost:        0,
-		TotalAspect: 0,
-	}
-
-	q := deque.New[*FlexNode](len(photos) / 4)
-	q.PushBack(root)
-	indexToNode := make(map[int]*FlexNode, len(photos))
-
-	maxLineWidth := rect.W
-	for q.Len() > 0 {
-		node := q.PopFront()
-		totalAspect := 0.
-		fallback := false
-		hasAux := false
-
-		// fmt.Printf("queue %d\n", node.Index)
-
-		prevHeight := photos[0].Height
-
-		for i := node.Index + 1; i < len(photos); i++ {
-			photo := photos[i]
-			totalAspect += float64(photo.AspectRatio)
-			totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
-			photoHeight := (maxLineWidth - totalSpacing) / totalAspect
-			minHeight := 0.3 * float64(photo.Height)
-			maxHeight := 1.7 * float64(photo.Height)
-			valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
-			// badness := math.Abs(photoHeight - idealHeight)
-			badness := math.Abs(photoHeight - float64(photo.Height))
-			prevDiff := 0.1 * math.Abs(float64(prevHeight-photo.Height))
-			prevHeight = photo.Height
-			// viewportDiff := 1000. * float64(photoHeight)
-			viewportDiff := 1000. * math.Max(0, float64(photoHeight)-layout.ViewportHeight)
-			cost := badness*badness + prevDiff*prevDiff + viewportDiff*viewportDiff + 10
-			// Incentivise aux items to be placed at the beginning
-			if i < len(photos)-1 && photos[i+1].Aux {
-				cost -= 1000000
-			}
-			if hasAux && photoHeight < minAuxHeight {
-				auxDiff := (minAuxHeight - photoHeight) * 4
-				cost += auxDiff * auxDiff
-			}
-			if photo.Aux {
-				hasAux = true
-			}
-			// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
-			if valid {
-				n, ok := indexToNode[i]
-				totalCost := node.Cost + float32(cost)
-				if ok {
-					if n.Cost > totalCost {
-						n.Cost = totalCost
-						n.TotalAspect = float32(totalAspect)
-						n.Shortest = node
-						// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
-					}
-					// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
-					// }
-				} else {
-					n = &FlexNode{
-						Index:       i,
-						Cost:        totalCost,
-						TotalAspect: float32(totalAspect),
-						Shortest:    node,
-					}
-					indexToNode[i] = n
-					if i < len(photos)-1 {
-						q.PushBack(n)
-					}
-					// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
-				}
-				// fmt.Printf("  node %d %v cost %f\n", i, ok, n.Cost)
-			}
-			if photoHeight < minHeight {
-				// Handle edge case where there is no other option
-				// but to accept a photo that would otherwise break outside of the desired size
-				if !fallback && i != len(photos)-1 && q.Len() == 0 {
-					fallback = true
-					for j := 0; j < 2 && i-j > node.Index; j++ {
-						totalAspect -= float64(photos[i-j].AspectRatio)
-					}
-					i = i - 2
-					if i < node.Index+1 {
-						i = node.Index + 1
-					}
-					continue
-				}
-				break
-			}
-		}
-	}
-
-	// dot := "digraph NodeGraph {\n"
-	// dot += root.Dot()
-	// dot += "}"
-	// fmt.Println(dot)
-
-	// Trace back the shortest path
-	shortestPath := make([]*FlexNode, 0)
-	for node := indexToNode[len(photos)-1]; node != nil; {
-		// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
-		shortestPath = append(shortestPath, node)
-		node = node.Shortest
-	}
-
-	// Finally, place the photos based on the shortest path breaks
-	x := 0.
-	y := 0.
-	idx := 0
-	for i := len(shortestPath) - 2; i >= 0; i-- {
-		node := shortestPath[i]
-		prev := shortestPath[i+1]
-		totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
-		imageHeight := (maxLineWidth - totalSpacing) / float64(node.TotalAspect)
-		// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
-		for ; idx <= node.Index; idx++ {
-			photo := photos[idx]
-			imageWidth := imageHeight * float64(photo.AspectRatio)
-
-			if photo.Aux {
-				aux := auxs[photo.Id]
-				size := imageHeight * 0.5
-				// lines := strings.Count(aux.Text, "\r") + 1
-				font := scene.Fonts.Main.Face(size, canvas.Dimgray, canvas.FontRegular, canvas.FontNormal)
-				// lineOffset := float64(lines-1) * size * 0.4
-				padding := 2.
-				text := render.Text{
-					Sprite: render.Sprite{
-						Rect: render.Rect{
-							X: rect.X + x + padding,
-							Y: rect.Y + y + padding,
-							W: imageWidth - 2*padding,
-							H: imageHeight - 2*padding,
-						},
-					},
-					Font:   &font,
-					Text:   aux.Text,
-					HAlign: canvas.Left,
-					VAlign: canvas.Bottom,
-				}
-				scene.Texts = append(scene.Texts, text)
-			} else {
-				scene.Photos = append(scene.Photos, render.Photo{
-					Id: photo.Id,
-					Sprite: render.Sprite{
-						Rect: render.Rect{
-							X: rect.X + x,
-							Y: rect.Y + y,
-							W: imageWidth,
-							H: imageHeight,
-						},
-					},
-				})
-			}
-			x += imageWidth + layout.ImageSpacing
-			// fmt.Printf("photo %d aspect %f height %f\n", idx, photo.AspectRatio, photo.Height)
-		}
-		x = 0
-		y += imageHeight + layout.LineSpacing
-	}
-
-	// fmt.Printf("photos %d indextonode %d stack %d\n", len(photos), len(indexToNode), q.Len())
-	// fmt.Printf("photos %d stack %d\n", cap(photos), q.Cap())
-
-	rect.H = rect.Y + y + sceneMargin - layout.LineSpacing
-	scene.Bounds.H = rect.H
-	layoutPlaced()
+	// rect.H = rect.Y + y + sceneMargin - layout.LineSpacing
+	// scene.Bounds.H = rect.H
+	// layoutPlaced()
 
 	scene.RegionSource = PhotoRegionSource{
 		Source: source,

--- a/internal/layout/highlights.go
+++ b/internal/layout/highlights.go
@@ -173,7 +173,10 @@ func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.S
 
 		// fmt.Printf("queue %d\n", node.Index)
 
-		prevHeight := photos[0].Height
+		prevHeight := float32(0.)
+		if nodeIndex+1 < len(photos) {
+			prevHeight = photos[nodeIndex+1].Height
+		}
 
 		for i := nodeIndex + 1; i < len(photos); i++ {
 			photo := photos[i]
@@ -185,7 +188,7 @@ func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.S
 			valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
 			// badness := math.Abs(photoHeight - idealHeight)
 			badness := math.Abs(photoHeight - float64(photo.Height))
-			prevDiff := 0.1 * math.Abs(float64(prevHeight-photo.Height))
+			prevDiff := 10 * math.Abs(float64(prevHeight-photo.Height))
 			prevHeight = photo.Height
 			// viewportDiff := 1000. * float64(photoHeight)
 			viewportDiff := 1000. * math.Max(0, float64(photoHeight)-layout.ViewportHeight)

--- a/internal/layout/highlights.go
+++ b/internal/layout/highlights.go
@@ -126,11 +126,10 @@ func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.S
 				prevEmb,
 				emb,
 			)
-			if err != nil {
-				log.Printf("dot product error: %v", err)
+			if err == nil {
+				similarity = dot * prevInvNorm * invnorm
+				simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
 			}
-			similarity = dot * prevInvNorm * invnorm
-			simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
 		}
 		prevEmb = emb
 		prevInvNorm = invnorm

--- a/internal/layout/highlights.go
+++ b/internal/layout/highlights.go
@@ -135,6 +135,10 @@ func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.S
 		prevEmb = emb
 		prevInvNorm = invnorm
 
+		if info.Width == 0 || info.Height == 0 {
+			info.Width = 3
+			info.Height = 2
+		}
 		photo := HighlightPhoto{
 			Photo: dag.Photo{
 				Id:          info.Id,

--- a/internal/layout/highlights.go
+++ b/internal/layout/highlights.go
@@ -3,329 +3,291 @@ package layout
 import (
 	// . "photofield/internal"
 
+	"context"
 	"log"
 	"math"
 	"photofield/internal/clip"
 	"photofield/internal/image"
+	"photofield/internal/layout/dag"
 	"photofield/internal/metrics"
 	"photofield/internal/render"
-	"strings"
 
 	"time"
+
+	"github.com/gammazero/deque"
+	"github.com/golang/geo/s2"
+	"github.com/tdewolff/canvas"
 )
 
 type HighlightPhoto struct {
-	FlexPhoto
+	dag.Photo
 	Height float32
-}
-
-func longestLine(s string) int {
-	lines := strings.Split(s, "\r")
-	longest := 0
-	for _, line := range lines {
-		if len(line) > longest {
-			longest = len(line)
-		}
-	}
-	return longest
 }
 
 func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.Scene, source *image.Source) {
 
-	// layout.ImageSpacing = math.Min(2, 0.02*layout.ImageHeight)
-	// layout.LineSpacing = layout.ImageSpacing
+	layout.ImageSpacing = math.Min(2, 0.02*layout.ImageHeight)
+	layout.LineSpacing = layout.ImageSpacing
 
-	// sceneMargin := 10.
+	sceneMargin := 10.
 
-	// scene.Bounds.W = layout.ViewportWidth
+	scene.Bounds.W = layout.ViewportWidth
 
-	// rect := render.Rect{
-	// 	X: sceneMargin,
-	// 	Y: sceneMargin + 64,
-	// 	W: scene.Bounds.W - sceneMargin*2,
-	// 	H: 0,
-	// }
+	rect := render.Rect{
+		X: sceneMargin,
+		Y: sceneMargin + 64,
+		W: scene.Bounds.W - sceneMargin*2,
+		H: 0,
+	}
 
-	// scene.Solids = make([]render.Solid, 0)
-	// scene.Texts = make([]render.Text, 0)
+	scene.Solids = make([]render.Solid, 0)
+	scene.Texts = make([]render.Text, 0)
 
-	// layoutPlaced := metrics.Elapsed("layout placing")
+	layoutPlaced := metrics.Elapsed("layout placing")
 
-	// // row := make([]SectionPhoto, 0)
+	idealHeight := math.Min(layout.ImageHeight, layout.ViewportHeight*0.9)
+	auxHeight := math.Max(80, idealHeight)
+	minAuxHeight := auxHeight * 0.8
+	minHeightFrac := 0.05
+	simMin := 0.6
+	// simPow := 3.3
+	// simPow := 0.7
+	// simPow := 0.3
+	// simPow := 1.8
+	simPow := 1.5
+	// simPow := 0.5
 
-	// // x := 0.
-	// // y := 0.
+	scene.Photos = scene.Photos[:0]
+	photos := make([]HighlightPhoto, 0)
 
-	// idealHeight := math.Min(layout.ImageHeight, layout.ViewportHeight*0.9)
-	// minHeightFrac := 0.05
-	// auxHeight := math.Max(80, idealHeight)
-	// minAuxHeight := auxHeight * 0.8
-	// simMin := 0.6
-	// // simPow := 3.3
-	// // simPow := 0.7
-	// // simPow := 0.3
-	// // simPow := 1.8
-	// simPow := 1.5
-	// // simPow := 0.5
+	layoutCounter := metrics.Counter{
+		Name:     "layout",
+		Interval: 1 * time.Second,
+	}
 
-	// // baseWidth := layout.ViewportWidth * 0.29
+	auxs := make([]dag.Aux, 0)
 
-	// // Gather all photos
-	// scene.Photos = scene.Photos[:0]
-	// photos := make([]HighlightPhoto, 0)
-	// var prevEmb []float32
-	// var prevInvNorm float32
-	// var prevLoc s2.LatLng
-	// var prevLocTime time.Time
-	// var prevLocation string
-	// var prevAuxTime time.Time
-	// layoutCounter := metrics.Counter{
-	// 	Name:     "layout",
-	// 	Interval: 1 * time.Second,
-	// }
-	// auxs := make([]FlexAux, 0)
-	// for info := range infos {
+	// Fetch all photos
+	var prevLoc s2.LatLng
+	var prevLocTime time.Time
+	var prevLocation string
+	var prevAuxTime time.Time
+	var prevEmb []float32
+	var prevInvNorm float32
 
-	// 	if source.Geo.Available() {
-	// 		photoTime := info.DateTime
-	// 		lastLocCheck := prevLocTime.Sub(photoTime)
-	// 		if lastLocCheck < 0 {
-	// 			lastLocCheck = -lastLocCheck
-	// 		}
-	// 		queryLocation := prevLocTime.IsZero() || lastLocCheck > 15*time.Minute
-	// 		// fmt.Printf("lastLocTime %v photoTime %v lastLocCheck %v queryLocation %v\n", lastLocTime, photoTime, lastLocCheck, queryLocation)
-	// 		if queryLocation && image.IsValidLatLng(info.LatLng) {
-	// 			prevLocTime = photoTime
-	// 			dist := image.AngleToKm(prevLoc.Distance(info.LatLng))
-	// 			if dist > 1 {
-	// 				location, err := source.Geo.ReverseGeocode(context.TODO(), info.LatLng)
-	// 				if err == nil && location != prevLocation {
-	// 					prevLocation = location
-	// 					text := ""
-	// 					if prevAuxTime.Year() != photoTime.Year() {
-	// 						text += photoTime.Format("2006\r")
-	// 					}
-	// 					if prevAuxTime.YearDay() != photoTime.YearDay() {
-	// 						text += photoTime.Format("Jan 2\rMonday\r")
-	// 					}
-	// 					prevAuxTime = photoTime
-	// 					text += location
-	// 					aux := FlexAux{
-	// 						Text: text,
-	// 					}
-	// 					auxs = append(auxs, aux)
-	// 					photos = append(photos, HighlightPhoto{
-	// 						FlexPhoto: FlexPhoto{
-	// 							Id:          image.ImageId(len(auxs) - 1),
-	// 							AspectRatio: 0.2 + float32(longestLine(text))/10,
-	// 							Aux:         true,
-	// 						},
-	// 						Height: float32(auxHeight),
-	// 					})
-	// 				}
-	// 				prevLoc = info.LatLng
-	// 			}
-	// 		}
-	// 	}
+	for info := range infos {
+		if source.Geo.Available() {
+			photoTime := info.DateTime
+			lastLocCheck := prevLocTime.Sub(photoTime)
+			if lastLocCheck < 0 {
+				lastLocCheck = -lastLocCheck
+			}
+			queryLocation := prevLocTime.IsZero() || lastLocCheck > 15*time.Minute
+			if queryLocation && image.IsValidLatLng(info.LatLng) {
+				prevLocTime = photoTime
+				dist := image.AngleToKm(prevLoc.Distance(info.LatLng))
+				if dist > 1 {
+					location, err := source.Geo.ReverseGeocode(context.TODO(), info.LatLng)
+					if err == nil && location != prevLocation {
+						prevLocation = location
+						text := ""
+						if prevAuxTime.Year() != photoTime.Year() {
+							text += photoTime.Format("2006\r")
+						}
+						if prevAuxTime.YearDay() != photoTime.YearDay() {
+							text += photoTime.Format("Jan 2\rMonday\r")
+						}
+						prevAuxTime = photoTime
+						text += location
+						aux := dag.Aux{
+							Text: text,
+						}
+						auxs = append(auxs, aux)
+						photos = append(photos, HighlightPhoto{
+							Photo: dag.Photo{
+								Id:          image.ImageId(len(auxs) - 1),
+								AspectRatio: 0.2 + float32(longestLine(text))/10,
+								Aux:         true,
+							},
+							Height: float32(auxHeight),
+						})
+					}
+					prevLoc = info.LatLng
+				}
+			}
+		}
 
-	// 	similarity := float32(0.)
-	// 	emb := info.Embedding.Float32()
-	// 	invnorm := info.Embedding.InvNormFloat32()
-	// 	simHeight := idealHeight
-	// 	if prevEmb != nil {
-	// 		dot, err := clip.DotProductFloat32Float32(
-	// 			prevEmb,
-	// 			emb,
-	// 		)
-	// 		if err != nil {
-	// 			log.Printf("dot product error: %v", err)
-	// 		}
-	// 		similarity = dot * prevInvNorm * invnorm
-	// 		simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
-	// 	}
-	// 	prevEmb = emb
-	// 	prevInvNorm = invnorm
+		similarity := float32(0.)
+		emb := info.Embedding.Float32()
+		invnorm := info.Embedding.InvNormFloat32()
+		simHeight := idealHeight
+		if prevEmb != nil {
+			dot, err := clip.DotProductFloat32Float32(
+				prevEmb,
+				emb,
+			)
+			if err != nil {
+				log.Printf("dot product error: %v", err)
+			}
+			similarity = dot * prevInvNorm * invnorm
+			simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
+		}
+		prevEmb = emb
+		prevInvNorm = invnorm
 
-	// 	photo := HighlightPhoto{
-	// 		FlexPhoto: FlexPhoto{
-	// 			Id:          info.Id,
-	// 			AspectRatio: float32(info.Width) / float32(info.Height),
-	// 		},
-	// 		Height: float32(simHeight),
-	// 	}
-	// 	photos = append(photos, photo)
-	// 	layoutCounter.Set(len(photos))
-	// }
+		photo := HighlightPhoto{
+			Photo: dag.Photo{
+				Id:          info.Id,
+				AspectRatio: float32(info.Width) / float32(info.Height),
+			},
+			Height: float32(simHeight),
+		}
+		photos = append(photos, photo)
+		layoutCounter.Set(len(photos))
+	}
 
-	// root := &FlexNode{
-	// 	Index:       -1,
-	// 	Cost:        0,
-	// 	TotalAspect: 0,
-	// }
+	// Create a directed acyclic graph to find the optimal layout
+	root := dag.Node{
+		Cost:           0,
+		TotalAspect:    0,
+		ShortestParent: -2,
+	}
 
-	// q := deque.New[*FlexNode](len(photos) / 4)
-	// q.PushBack(root)
-	// indexToNode := make(map[int]*FlexNode, len(photos))
+	q := deque.New[dag.Index](len(photos) / 4)
+	q.PushBack(-1)
+	indexToNode := make(map[dag.Index]dag.Node, len(photos))
+	indexToNode[-1] = root
 
-	// maxLineWidth := rect.W
-	// for q.Len() > 0 {
-	// 	node := q.PopFront()
-	// 	totalAspect := 0.
-	// 	fallback := false
-	// 	hasAux := false
+	maxLineWidth := rect.W
 
-	// 	// fmt.Printf("queue %d\n", node.Index)
+	for q.Len() > 0 {
+		nodeIndex := q.PopFront()
+		node := indexToNode[nodeIndex]
+		totalAspect := 0.
+		fallback := false
+		hasAux := false
 
-	// 	prevHeight := photos[0].Height
+		// fmt.Printf("queue %d\n", node.Index)
 
-	// 	for i := node.Index + 1; i < len(photos); i++ {
-	// 		photo := photos[i]
-	// 		totalAspect += float64(photo.AspectRatio)
-	// 		totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
-	// 		photoHeight := (maxLineWidth - totalSpacing) / totalAspect
-	// 		minHeight := 0.3 * float64(photo.Height)
-	// 		maxHeight := 1.7 * float64(photo.Height)
-	// 		valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
-	// 		// badness := math.Abs(photoHeight - idealHeight)
-	// 		badness := math.Abs(photoHeight - float64(photo.Height))
-	// 		prevDiff := 0.1 * math.Abs(float64(prevHeight-photo.Height))
-	// 		prevHeight = photo.Height
-	// 		// viewportDiff := 1000. * float64(photoHeight)
-	// 		viewportDiff := 1000. * math.Max(0, float64(photoHeight)-layout.ViewportHeight)
-	// 		cost := badness*badness + prevDiff*prevDiff + viewportDiff*viewportDiff + 10
-	// 		// Incentivise aux items to be placed at the beginning
-	// 		if i < len(photos)-1 && photos[i+1].Aux {
-	// 			cost -= 1000000
-	// 		}
-	// 		if hasAux && photoHeight < minAuxHeight {
-	// 			auxDiff := (minAuxHeight - photoHeight) * 4
-	// 			cost += auxDiff * auxDiff
-	// 		}
-	// 		if photo.Aux {
-	// 			hasAux = true
-	// 		}
-	// 		// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
-	// 		if valid {
-	// 			n, ok := indexToNode[i]
-	// 			totalCost := node.Cost + float32(cost)
-	// 			if ok {
-	// 				if n.Cost > totalCost {
-	// 					n.Cost = totalCost
-	// 					n.TotalAspect = float32(totalAspect)
-	// 					n.ShortestParent = node
-	// 					// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
-	// 				}
-	// 				// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
-	// 				// }
-	// 			} else {
-	// 				n = &FlexNode{
-	// 					Index:          i,
-	// 					Cost:           totalCost,
-	// 					TotalAspect:    float32(totalAspect),
-	// 					ShortestParent: node,
-	// 				}
-	// 				indexToNode[i] = n
-	// 				if i < len(photos)-1 {
-	// 					q.PushBack(n)
-	// 				}
-	// 				// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
-	// 			}
-	// 			// fmt.Printf("  node %d %v cost %f\n", i, ok, n.Cost)
-	// 		}
-	// 		if photoHeight < minHeight {
-	// 			// Handle edge case where there is no other option
-	// 			// but to accept a photo that would otherwise break outside of the desired size
-	// 			if !fallback && i != len(photos)-1 && q.Len() == 0 {
-	// 				fallback = true
-	// 				for j := 0; j < 2 && i-j > node.Index; j++ {
-	// 					totalAspect -= float64(photos[i-j].AspectRatio)
-	// 				}
-	// 				i = i - 2
-	// 				if i < node.Index+1 {
-	// 					i = node.Index + 1
-	// 				}
-	// 				continue
-	// 			}
-	// 			break
-	// 		}
-	// 	}
-	// }
+		prevHeight := photos[0].Height
 
-	// // dot := "digraph NodeGraph {\n"
-	// // dot += root.Dot()
-	// // dot += "}"
-	// // fmt.Println(dot)
+		for i := nodeIndex + 1; i < len(photos); i++ {
+			photo := photos[i]
+			totalAspect += float64(photo.AspectRatio)
+			totalSpacing := layout.ImageSpacing * float64(i-1-nodeIndex)
+			photoHeight := (maxLineWidth - totalSpacing) / totalAspect
+			minHeight := 0.3 * float64(photo.Height)
+			maxHeight := 1.7 * float64(photo.Height)
+			valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
+			// badness := math.Abs(photoHeight - idealHeight)
+			badness := math.Abs(photoHeight - float64(photo.Height))
+			prevDiff := 0.1 * math.Abs(float64(prevHeight-photo.Height))
+			prevHeight = photo.Height
+			// viewportDiff := 1000. * float64(photoHeight)
+			viewportDiff := 1000. * math.Max(0, float64(photoHeight)-layout.ViewportHeight)
+			cost := badness*badness + prevDiff*prevDiff + viewportDiff*viewportDiff + 10
+			// Incentivise aux items to be placed at the beginning
+			if i < len(photos)-1 && photos[i+1].Aux {
+				cost -= 1000000
+			}
+			if hasAux && photoHeight < minAuxHeight {
+				auxDiff := (minAuxHeight - photoHeight) * 4
+				cost += auxDiff * auxDiff
+			}
+			if photo.Aux {
+				hasAux = true
+			}
+			if valid {
+				totalCost := node.Cost + float32(cost)
+				n, ok := indexToNode[i]
+				if !ok || (ok && n.Cost > totalCost) {
+					n.Cost = totalCost
+					n.TotalAspect = float32(totalAspect)
+					n.ShortestParent = nodeIndex
+				}
+				if !ok && i < len(photos)-1 {
+					q.PushBack(i)
+				}
+				indexToNode[i] = n
+			}
+			if photoHeight < minHeight {
+				// Handle edge case where there is no other option
+				// but to accept a photo that would otherwise break outside of the desired size
+				if !fallback && i != len(photos)-1 && q.Len() == 0 {
+					fallback = true
+					for j := 0; j < 2 && i > nodeIndex; j++ {
+						totalAspect -= float64(photos[i].AspectRatio)
+						i--
+					}
+					continue
+				}
+				break
+			}
+		}
+	}
 
-	// // Trace back the shortest path
-	// shortestPath := make([]*FlexNode, 0)
-	// for node := indexToNode[len(photos)-1]; node != nil; {
-	// 	// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
-	// 	shortestPath = append(shortestPath, node)
-	// 	node = node.ShortestParent
-	// }
+	// Trace back the shortest path
+	shortestPath := make([]int, 0)
+	for nodeIndex := len(photos) - 1; nodeIndex != -2; {
+		shortestPath = append(shortestPath, nodeIndex)
+		nodeIndex = indexToNode[nodeIndex].ShortestParent
+	}
 
-	// // Finally, place the photos based on the shortest path breaks
-	// x := 0.
-	// y := 0.
-	// idx := 0
-	// for i := len(shortestPath) - 2; i >= 0; i-- {
-	// 	node := shortestPath[i]
-	// 	prev := shortestPath[i+1]
-	// 	totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
-	// 	imageHeight := (maxLineWidth - totalSpacing) / float64(node.TotalAspect)
-	// 	// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
-	// 	for ; idx <= node.Index; idx++ {
-	// 		photo := photos[idx]
-	// 		imageWidth := imageHeight * float64(photo.AspectRatio)
+	// Finally, place the photos based on the shortest path breaks
+	x := 0.
+	y := 0.
+	idx := 0
+	for i := len(shortestPath) - 2; i >= 0; i-- {
+		nodeIdx := shortestPath[i]
+		prevIdx := shortestPath[i+1]
+		node := indexToNode[nodeIdx]
+		totalSpacing := layout.ImageSpacing * float64(nodeIdx-1-prevIdx)
+		imageHeight := (maxLineWidth - totalSpacing) / float64(node.TotalAspect)
+		for ; idx <= nodeIdx; idx++ {
+			photo := photos[idx]
+			imageWidth := imageHeight * float64(photo.AspectRatio)
+			if photo.Aux {
+				aux := auxs[photo.Id]
+				size := imageHeight * 0.5
+				font := scene.Fonts.Main.Face(size, canvas.Dimgray, canvas.FontRegular, canvas.FontNormal)
+				padding := 2.
+				text := render.Text{
+					Sprite: render.Sprite{
+						Rect: render.Rect{
+							X: rect.X + x + padding,
+							Y: rect.Y + y + padding,
+							W: imageWidth - 2*padding,
+							H: imageHeight - 2*padding,
+						},
+					},
+					Font:   &font,
+					Text:   aux.Text,
+					HAlign: canvas.Left,
+					VAlign: canvas.Bottom,
+				}
+				scene.Texts = append(scene.Texts, text)
+			} else {
+				scene.Photos = append(scene.Photos, render.Photo{
+					Id: photo.Id,
+					Sprite: render.Sprite{
+						Rect: render.Rect{
+							X: rect.X + x,
+							Y: rect.Y + y,
+							W: imageWidth,
+							H: imageHeight,
+						},
+					},
+				})
+			}
+			x += imageWidth + layout.ImageSpacing
+		}
+		x = 0
+		y += imageHeight + layout.LineSpacing
+	}
 
-	// 		if photo.Aux {
-	// 			aux := auxs[photo.Id]
-	// 			size := imageHeight * 0.5
-	// 			// lines := strings.Count(aux.Text, "\r") + 1
-	// 			font := scene.Fonts.Main.Face(size, canvas.Dimgray, canvas.FontRegular, canvas.FontNormal)
-	// 			// lineOffset := float64(lines-1) * size * 0.4
-	// 			padding := 2.
-	// 			text := render.Text{
-	// 				Sprite: render.Sprite{
-	// 					Rect: render.Rect{
-	// 						X: rect.X + x + padding,
-	// 						Y: rect.Y + y + padding,
-	// 						W: imageWidth - 2*padding,
-	// 						H: imageHeight - 2*padding,
-	// 					},
-	// 				},
-	// 				Font:   &font,
-	// 				Text:   aux.Text,
-	// 				HAlign: canvas.Left,
-	// 				VAlign: canvas.Bottom,
-	// 			}
-	// 			scene.Texts = append(scene.Texts, text)
-	// 		} else {
-	// 			scene.Photos = append(scene.Photos, render.Photo{
-	// 				Id: photo.Id,
-	// 				Sprite: render.Sprite{
-	// 					Rect: render.Rect{
-	// 						X: rect.X + x,
-	// 						Y: rect.Y + y,
-	// 						W: imageWidth,
-	// 						H: imageHeight,
-	// 					},
-	// 				},
-	// 			})
-	// 		}
-	// 		x += imageWidth + layout.ImageSpacing
-	// 		// fmt.Printf("photo %d aspect %f height %f\n", idx, photo.AspectRatio, photo.Height)
-	// 	}
-	// 	x = 0
-	// 	y += imageHeight + layout.LineSpacing
-	// }
-
-	// // fmt.Printf("photos %d indextonode %d stack %d\n", len(photos), len(indexToNode), q.Len())
-	// // fmt.Printf("photos %d stack %d\n", cap(photos), q.Cap())
-
-	// rect.H = rect.Y + y + sceneMargin - layout.LineSpacing
-	// scene.Bounds.H = rect.H
-	// layoutPlaced()
+	rect.H = rect.Y + y + sceneMargin - layout.LineSpacing
+	scene.Bounds.H = rect.H
+	layoutPlaced()
 
 	scene.RegionSource = PhotoRegionSource{
 		Source: source,

--- a/internal/layout/highlights.go
+++ b/internal/layout/highlights.go
@@ -1,0 +1,479 @@
+package layout
+
+import (
+	// . "photofield/internal"
+
+	"context"
+	"log"
+	"math"
+	"photofield/internal/clip"
+	"photofield/internal/image"
+	"photofield/internal/metrics"
+	"photofield/internal/render"
+	"strings"
+
+	"time"
+
+	"github.com/gammazero/deque"
+	"github.com/golang/geo/s2"
+	"github.com/tdewolff/canvas"
+)
+
+type HighlightPhoto struct {
+	FlexPhoto
+	Height float32
+}
+
+func longestLine(s string) int {
+	lines := strings.Split(s, "\r")
+	longest := 0
+	for _, line := range lines {
+		if len(line) > longest {
+			longest = len(line)
+		}
+	}
+	return longest
+}
+
+func LayoutHighlights(infos <-chan image.InfoEmb, layout Layout, scene *render.Scene, source *image.Source) {
+
+	layout.ImageSpacing = math.Min(2, 0.02*layout.ImageHeight)
+	layout.LineSpacing = layout.ImageSpacing
+
+	sceneMargin := 10.
+
+	scene.Bounds.W = layout.ViewportWidth
+
+	rect := render.Rect{
+		X: sceneMargin,
+		Y: sceneMargin + 64,
+		W: scene.Bounds.W - sceneMargin*2,
+		H: 0,
+	}
+
+	scene.Solids = make([]render.Solid, 0)
+	scene.Texts = make([]render.Text, 0)
+
+	layoutPlaced := metrics.Elapsed("layout placing")
+
+	// row := make([]SectionPhoto, 0)
+
+	// x := 0.
+	// y := 0.
+
+	idealHeight := math.Min(layout.ImageHeight, layout.ViewportHeight*0.9)
+	minHeightFrac := 0.05
+	auxHeight := math.Max(80, idealHeight)
+	minAuxHeight := auxHeight * 0.8
+	simMin := 0.6
+	// simPow := 3.3
+	// simPow := 0.7
+	// simPow := 0.3
+	// simPow := 1.8
+	simPow := 1.5
+	// simPow := 0.5
+
+	// baseWidth := layout.ViewportWidth * 0.29
+
+	// Gather all photos
+	scene.Photos = scene.Photos[:0]
+	photos := make([]HighlightPhoto, 0)
+	var prevEmb []float32
+	var prevInvNorm float32
+	var prevLoc s2.LatLng
+	var prevLocTime time.Time
+	var prevLocation string
+	var prevAuxTime time.Time
+	layoutCounter := metrics.Counter{
+		Name:     "layout",
+		Interval: 1 * time.Second,
+	}
+	auxs := make([]FlexAux, 0)
+	for info := range infos {
+
+		if source.Geo.Available() {
+			photoTime := info.DateTime
+			lastLocCheck := prevLocTime.Sub(photoTime)
+			if lastLocCheck < 0 {
+				lastLocCheck = -lastLocCheck
+			}
+			queryLocation := prevLocTime.IsZero() || lastLocCheck > 15*time.Minute
+			// fmt.Printf("lastLocTime %v photoTime %v lastLocCheck %v queryLocation %v\n", lastLocTime, photoTime, lastLocCheck, queryLocation)
+			if queryLocation && image.IsValidLatLng(info.LatLng) {
+				prevLocTime = photoTime
+				dist := image.AngleToKm(prevLoc.Distance(info.LatLng))
+				if dist > 1 {
+					location, err := source.Geo.ReverseGeocode(context.TODO(), info.LatLng)
+					if err == nil && location != prevLocation {
+						prevLocation = location
+						text := ""
+						if prevAuxTime.Year() != photoTime.Year() {
+							text += photoTime.Format("2006\r")
+						}
+						if prevAuxTime.YearDay() != photoTime.YearDay() {
+							text += photoTime.Format("Jan 2\rMonday\r")
+						}
+						prevAuxTime = photoTime
+						text += location
+						aux := FlexAux{
+							Text: text,
+						}
+						auxs = append(auxs, aux)
+						photos = append(photos, HighlightPhoto{
+							FlexPhoto: FlexPhoto{
+								Id:          image.ImageId(len(auxs) - 1),
+								AspectRatio: 0.2 + float32(longestLine(text))/10,
+								Aux:         true,
+							},
+							Height: float32(auxHeight),
+						})
+					}
+					prevLoc = info.LatLng
+				}
+			}
+		}
+
+		similarity := float32(0.)
+		emb := info.Embedding.Float32()
+		invnorm := info.Embedding.InvNormFloat32()
+		simHeight := idealHeight
+		if prevEmb != nil {
+			dot, err := clip.DotProductFloat32Float32(
+				prevEmb,
+				emb,
+			)
+			if err != nil {
+				log.Printf("dot product error: %v", err)
+			}
+			similarity = dot * prevInvNorm * invnorm
+			simHeight = idealHeight * math.Min(1, minHeightFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minHeightFrac))
+		}
+		prevEmb = emb
+		prevInvNorm = invnorm
+
+		photo := HighlightPhoto{
+			FlexPhoto: FlexPhoto{
+				Id:          info.Id,
+				AspectRatio: float32(info.Width) / float32(info.Height),
+			},
+			Height: float32(simHeight),
+		}
+		photos = append(photos, photo)
+		layoutCounter.Set(len(photos))
+	}
+
+	root := &FlexNode{
+		Index:       -1,
+		Cost:        0,
+		TotalAspect: 0,
+	}
+
+	q := deque.New[*FlexNode](len(photos) / 4)
+	q.PushBack(root)
+	indexToNode := make(map[int]*FlexNode, len(photos))
+
+	maxLineWidth := rect.W
+	for q.Len() > 0 {
+		node := q.PopFront()
+		totalAspect := 0.
+		fallback := false
+		hasAux := false
+
+		// fmt.Printf("queue %d\n", node.Index)
+
+		prevHeight := photos[0].Height
+
+		for i := node.Index + 1; i < len(photos); i++ {
+			photo := photos[i]
+			totalAspect += float64(photo.AspectRatio)
+			totalSpacing := layout.ImageSpacing * float64(i-1-node.Index)
+			photoHeight := (maxLineWidth - totalSpacing) / totalAspect
+			minHeight := 0.3 * float64(photo.Height)
+			maxHeight := 1.7 * float64(photo.Height)
+			valid := photoHeight >= minHeight && photoHeight <= maxHeight || i == len(photos)-1 || fallback
+			// badness := math.Abs(photoHeight - idealHeight)
+			badness := math.Abs(photoHeight - float64(photo.Height))
+			prevDiff := 0.1 * math.Abs(float64(prevHeight-photo.Height))
+			prevHeight = photo.Height
+			// viewportDiff := 1000. * float64(photoHeight)
+			viewportDiff := 1000. * math.Max(0, float64(photoHeight)-layout.ViewportHeight)
+			cost := badness*badness + prevDiff*prevDiff + viewportDiff*viewportDiff + 10
+			// Incentivise aux items to be placed at the beginning
+			if i < len(photos)-1 && photos[i+1].Aux {
+				cost -= 1000000
+			}
+			if hasAux && photoHeight < minAuxHeight {
+				auxDiff := (minAuxHeight - photoHeight) * 4
+				cost += auxDiff * auxDiff
+			}
+			if photo.Aux {
+				hasAux = true
+			}
+			// fmt.Printf("  photo %d aspect %f total %f width %f height %f valid %v badness %f cost %f\n", i, photo.AspectRatio, totalAspect, maxLineWidth, photoHeight, valid, badness, cost)
+			if valid {
+				n, ok := indexToNode[i]
+				totalCost := node.Cost + float32(cost)
+				if ok {
+					if n.Cost > totalCost {
+						n.Cost = totalCost
+						n.TotalAspect = float32(totalAspect)
+						n.Shortest = node
+						// fmt.Printf("  node %d exists, lower cost %f\n", i, n.Cost)
+					}
+					// fmt.Printf("  node %d exists, keep cost %f\n", i, n.Cost)
+					// }
+				} else {
+					n = &FlexNode{
+						Index:       i,
+						Cost:        totalCost,
+						TotalAspect: float32(totalAspect),
+						Shortest:    node,
+					}
+					indexToNode[i] = n
+					if i < len(photos)-1 {
+						q.PushBack(n)
+					}
+					// fmt.Printf("  node %d added with cost %f\n", i, n.Cost)
+				}
+				// fmt.Printf("  node %d %v cost %f\n", i, ok, n.Cost)
+			}
+			if photoHeight < minHeight {
+				// Handle edge case where there is no other option
+				// but to accept a photo that would otherwise break outside of the desired size
+				if !fallback && i != len(photos)-1 && q.Len() == 0 {
+					fallback = true
+					for j := 0; j < 2 && i-j > node.Index; j++ {
+						totalAspect -= float64(photos[i-j].AspectRatio)
+					}
+					i = i - 2
+					if i < node.Index+1 {
+						i = node.Index + 1
+					}
+					continue
+				}
+				break
+			}
+		}
+	}
+
+	// dot := "digraph NodeGraph {\n"
+	// dot += root.Dot()
+	// dot += "}"
+	// fmt.Println(dot)
+
+	// Trace back the shortest path
+	shortestPath := make([]*FlexNode, 0)
+	for node := indexToNode[len(photos)-1]; node != nil; {
+		// fmt.Printf("node %d cost %f\n", node.Index, node.Cost)
+		shortestPath = append(shortestPath, node)
+		node = node.Shortest
+	}
+
+	// Finally, place the photos based on the shortest path breaks
+	x := 0.
+	y := 0.
+	idx := 0
+	for i := len(shortestPath) - 2; i >= 0; i-- {
+		node := shortestPath[i]
+		prev := shortestPath[i+1]
+		totalSpacing := layout.ImageSpacing * float64(node.Index-1-prev.Index)
+		imageHeight := (maxLineWidth - totalSpacing) / float64(node.TotalAspect)
+		// fmt.Printf("node %d (%d) cost %f total aspect %f height %f\n", node.Index, prev.Index, node.Cost, node.TotalAspect, imageHeight)
+		for ; idx <= node.Index; idx++ {
+			photo := photos[idx]
+			imageWidth := imageHeight * float64(photo.AspectRatio)
+
+			if photo.Aux {
+				aux := auxs[photo.Id]
+				size := imageHeight * 0.5
+				// lines := strings.Count(aux.Text, "\r") + 1
+				font := scene.Fonts.Main.Face(size, canvas.Dimgray, canvas.FontRegular, canvas.FontNormal)
+				// lineOffset := float64(lines-1) * size * 0.4
+				padding := 2.
+				text := render.Text{
+					Sprite: render.Sprite{
+						Rect: render.Rect{
+							X: rect.X + x + padding,
+							Y: rect.Y + y + padding,
+							W: imageWidth - 2*padding,
+							H: imageHeight - 2*padding,
+						},
+					},
+					Font:   &font,
+					Text:   aux.Text,
+					HAlign: canvas.Left,
+					VAlign: canvas.Bottom,
+				}
+				scene.Texts = append(scene.Texts, text)
+			} else {
+				scene.Photos = append(scene.Photos, render.Photo{
+					Id: photo.Id,
+					Sprite: render.Sprite{
+						Rect: render.Rect{
+							X: rect.X + x,
+							Y: rect.Y + y,
+							W: imageWidth,
+							H: imageHeight,
+						},
+					},
+				})
+			}
+			x += imageWidth + layout.ImageSpacing
+			// fmt.Printf("photo %d aspect %f height %f\n", idx, photo.AspectRatio, photo.Height)
+		}
+		x = 0
+		y += imageHeight + layout.LineSpacing
+	}
+
+	// fmt.Printf("photos %d indextonode %d stack %d\n", len(photos), len(indexToNode), q.Len())
+	// fmt.Printf("photos %d stack %d\n", cap(photos), q.Cap())
+
+	rect.H = rect.Y + y + sceneMargin - layout.LineSpacing
+	scene.Bounds.H = rect.H
+	layoutPlaced()
+
+	scene.RegionSource = PhotoRegionSource{
+		Source: source,
+	}
+}
+
+func LayoutHighlightsBasic(infos <-chan image.InfoEmb, layout Layout, scene *render.Scene, source *image.Source) {
+
+	layout.ImageSpacing = 0.02 * layout.ImageHeight
+	layout.LineSpacing = 0.02 * layout.ImageHeight
+
+	sceneMargin := 10.
+
+	scene.Bounds.W = layout.ViewportWidth
+
+	rect := render.Rect{
+		X: sceneMargin,
+		Y: sceneMargin + 64,
+		W: scene.Bounds.W - sceneMargin*2,
+		H: 0,
+	}
+
+	// section := Section{}
+
+	scene.Solids = make([]render.Solid, 0)
+	scene.Texts = make([]render.Text, 0)
+
+	layoutPlaced := metrics.Elapsed("layout placing")
+	layoutCounter := metrics.Counter{
+		Name:     "layout",
+		Interval: 1 * time.Second,
+	}
+
+	row := make([]SectionPhoto, 0)
+
+	x := 0.
+	y := 0.
+
+	simMin := 0.5
+	simPow := 3.3
+	// simPow := 0.7
+	maxWidthFrac := 0.49
+	minWidthFrac := 0.05
+	baseWidth := layout.ViewportWidth * maxWidthFrac
+
+	var prevEmb []float32
+	var prevInvNorm float32
+
+	scene.Photos = scene.Photos[:0]
+	index := 0
+	for info := range infos {
+		photo := SectionPhoto{
+			Photo: render.Photo{
+				Id:     info.Id,
+				Sprite: render.Sprite{},
+			},
+			Size: image.Size{
+				X: info.Width,
+				Y: info.Height,
+			},
+		}
+		// section.infos = append(section.infos, info.SourcedInfo)
+
+		similarity := float32(0.)
+		emb := info.Embedding.Float32()
+		invnorm := info.Embedding.InvNormFloat32()
+		if prevEmb != nil {
+			dot, err := clip.DotProductFloat32Float32(
+				prevEmb,
+				emb,
+			)
+			if err != nil {
+				log.Printf("dot product error: %v", err)
+			}
+			similarity = dot * prevInvNorm * invnorm
+		}
+		prevEmb = emb
+		prevInvNorm = invnorm
+
+		// simWidth := baseWidth * math.Pow(math.Min(1., 1-(float64(similarity)-simMin)), simPow)
+		simWidth := baseWidth * math.Min(1, minWidthFrac+math.Pow(1-(float64(similarity)-simMin)/(1-simMin), simPow)*(1-minWidthFrac))
+
+		// fmt.Printf("id: %6d, similarity: %f, width: %f / %f\n", info.Id, similarity, simWidth, baseWidth)
+
+		// aspectRatio := float64(photo.Size.X) / float64(photo.Size.Y)
+		imageWidth := simWidth
+		// imageHeight := imageWidth / aspectRatio
+
+		if x+imageWidth > rect.W {
+
+			x = 0
+			for i := range row {
+				photo := &row[i]
+				photo.Photo.Sprite.PlaceFitHeight(
+					rect.X+x,
+					rect.Y+y,
+					layout.ImageHeight,
+					float64(photo.Size.X),
+					float64(photo.Size.Y),
+				)
+				x += photo.Sprite.Rect.W + layout.ImageSpacing
+			}
+			x -= layout.ImageSpacing
+
+			scale := layoutFitRow(row, rect, layout.ImageSpacing)
+
+			for _, p := range row {
+				scene.Photos = append(scene.Photos, p.Photo)
+			}
+			row = nil
+			x = 0
+			y += layout.ImageHeight*scale + layout.LineSpacing
+		}
+
+		photo.Photo.Sprite.PlaceFitWidth(
+			rect.X+x,
+			rect.Y+y,
+			imageWidth,
+			float64(photo.Size.X),
+			float64(photo.Size.Y),
+		)
+
+		row = append(row, photo)
+
+		x += imageWidth + layout.ImageSpacing
+
+		layoutCounter.Set(index)
+		index++
+		scene.FileCount = index
+	}
+	for _, p := range row {
+		scene.Photos = append(scene.Photos, p.Photo)
+	}
+	x = 0
+	y += layout.ImageHeight + layout.LineSpacing
+
+	rect.Y = y
+
+	// newBounds := addSectionToScene(&section, scene, rect, layout, source)
+	layoutPlaced()
+
+	scene.Bounds.H = rect.Y + sceneMargin
+	scene.RegionSource = PhotoRegionSource{
+		Source: source,
+	}
+}

--- a/internal/layout/timeline.go
+++ b/internal/layout/timeline.go
@@ -53,14 +53,14 @@ func LayoutTimelineEvent(layout Layout, rect render.Rect, event *TimelineEvent, 
 
 	font := scene.Fonts.Main.Face(40, canvas.Black, canvas.FontRegular, canvas.FontNormal)
 
-	scene.Texts = append(scene.Texts,
-		render.NewTextFromRect(
-			textBounds,
-			&font,
-			headerText,
-		),
+	text := render.NewTextFromRect(
+		textBounds,
+		&font,
+		headerText,
 	)
-	rect.Y += textHeight + 15
+	text.VAlign = canvas.Bottom
+	scene.Texts = append(scene.Texts, text)
+	rect.Y += textHeight + 4
 
 	newBounds := addSectionToScene(&event.Section, scene, rect, layout, source)
 

--- a/internal/render/sprite.go
+++ b/internal/render/sprite.go
@@ -30,6 +30,26 @@ func (sprite *Sprite) PlaceFitHeight(
 	}
 }
 
+func (sprite *Sprite) PlaceFitWidth(
+	x float64,
+	y float64,
+	fitWidth float64,
+	contentWidth float64,
+	contentHeight float64,
+) {
+	scale := fitWidth / contentWidth
+	if math.IsNaN(scale) || math.IsInf(scale, 0) {
+		scale = 1
+	}
+
+	sprite.Rect = Rect{
+		X: x,
+		Y: y,
+		W: contentWidth * scale,
+		H: contentHeight * scale,
+	}
+}
+
 func (sprite *Sprite) PlaceFit(
 	x float64,
 	y float64,

--- a/internal/render/text.go
+++ b/internal/render/text.go
@@ -10,6 +10,8 @@ type Text struct {
 	Sprite Sprite
 	Font   *canvas.FontFace
 	Text   string
+	HAlign canvas.TextAlign
+	VAlign canvas.TextAlign
 }
 
 func NewTextFromRect(rect Rect, font *canvas.FontFace, txt string) Text {
@@ -28,7 +30,10 @@ func (text *Text) Draw(config *Render, c *canvas.Context, scales Scales) {
 			return
 		}
 
-		textLine := canvas.NewTextLine(*text.Font, text.Text, canvas.Left)
-		c.RenderText(textLine, c.View().Mul(text.Sprite.Rect.GetMatrix()))
+		// textLine := canvas.NewTextLine(*text.Font, text.Text, canvas.Left)
+		textLine := canvas.NewTextBox(*text.Font, text.Text, text.Sprite.Rect.W, text.Sprite.Rect.H, text.HAlign, text.VAlign, 0, 0)
+		rect := text.Sprite.Rect
+		rect.Y -= rect.H
+		c.RenderText(textLine, c.View().Mul(rect.GetMatrix()))
 	}
 }

--- a/internal/render/text.go
+++ b/internal/render/text.go
@@ -30,7 +30,6 @@ func (text *Text) Draw(config *Render, c *canvas.Context, scales Scales) {
 			return
 		}
 
-		// textLine := canvas.NewTextLine(*text.Font, text.Text, canvas.Left)
 		textLine := canvas.NewTextBox(*text.Font, text.Text, text.Sprite.Rect.W, text.Sprite.Rect.H, text.HAlign, text.VAlign, 0, 0)
 		rect := text.Sprite.Rect
 		rect.Y -= rect.H

--- a/internal/scene/sceneSource.go
+++ b/internal/scene/sceneSource.go
@@ -111,7 +111,14 @@ func (source *SceneSource) loadScene(config SceneConfig, imageSource *image.Sour
 			searchDone()
 		}
 
-		if scene.SearchEmbedding != nil {
+		if config.Layout.Type == layout.Highlights {
+			infos := imageSource.ListInfosEmb(config.Collection.Dirs, image.ListOptions{
+				OrderBy: image.ListOrder(config.Layout.Order),
+				Limit:   config.Collection.Limit,
+			})
+
+			layout.LayoutHighlights(infos, config.Layout, &scene, imageSource)
+		} else if scene.SearchEmbedding != nil {
 			// Similarity order
 			infos := config.Collection.GetSimilar(imageSource, scene.SearchEmbedding, image.ListOptions{
 				Limit: config.Collection.Limit,
@@ -144,6 +151,8 @@ func (source *SceneSource) loadScene(config SceneConfig, imageSource *image.Sour
 				layout.LayoutMap(infos, config.Layout, &scene, imageSource)
 			case layout.Strip:
 				layout.LayoutStrip(infos, config.Layout, &scene, imageSource)
+			case layout.Flex:
+				layout.LayoutFlex(infos, config.Layout, &scene, imageSource)
 			default:
 				layout.LayoutAlbum(infos, config.Layout, &scene, imageSource)
 			}

--- a/main.go
+++ b/main.go
@@ -1237,7 +1237,7 @@ func applyConfig(appConfig *AppConfig) {
 		log.Printf("%v", globalGeo.String())
 	}
 
-	imageSource = image.NewSource(appConfig.Media, migrations, migrationsThumbs, nil)
+	imageSource = image.NewSource(appConfig.Media, migrations, migrationsThumbs, globalGeo)
 	imageSource.HandleDirUpdates(invalidateDirs)
 	if tileRequestConfig.Concurrency > 0 {
 		log.Printf("request concurrency %v", tileRequestConfig.Concurrency)

--- a/ui/src/components/DisplaySettings.vue
+++ b/ui/src/components/DisplaySettings.vue
@@ -66,6 +66,8 @@ const layoutOptions = ref([
     { label: "Timeline", value: "TIMELINE" },
     { label: "Wall", value: "WALL" },
     { label: "Map", value: "MAP" },
+    { label: "Highlights", value: "HIGHLIGHTS" },
+    { label: "Flex", value: "FLEX" },
 ]);
 
 const extra = ref(false);


### PR DESCRIPTION
Both layouts are based on finding optimal photo row breaks using a variant of Knuth & Plass.

## Flex
![image](https://github.com/SmilyOrg/photofield/assets/1451391/d97b9a82-3df8-4be1-920a-8ce7abb859f4)

Flex is the simpler layout of the two where all rows are approximately the same height. Think of it as Album with smarter row breaks.

Mostly noticable with panoramas and at the end of the collection (it will try to avoid photos hanging off the end). It will also add locations inline if photos have GPS coordinates and reverse geocoding is enabled.

## Highlights

![image](https://github.com/SmilyOrg/photofield/assets/1451391/7674dde6-957e-4389-9fd4-214bd633b3b6)

Highlights is a more experimental variant on Flex, but with a bit of a twist! Instead of a more or less content row height, it will try to vary it based on the "sameness" of the photos. Best used with bigger photo sizes (pictured button).

The idea is to make travel photo collections more skimmable by shrinking similar and repeating photos.

Similarity is based on the AI image embeddings, so photos close in "meaning" will be considered as semantically similar. Seems to work quite well, but you need to have AI enabled and photos scanned for it to work as expected.

## TODO

- [x] make it handle non-ai-indexed photos more gracefully than just skipping them