### PR TITLE
Faster large collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ version zero.
 ### Added
 
 - Enable search even if AI is not enabled
+- Add `skip_collection_counts` config option for faster startup in some cases
 
 ### Changed
 
-- None
+- Optimized loading very large collections (100K .. 10M+ files)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ version zero.
 ### Changed
 
 - Optimized loading very large collections (100K .. 10M+ files)
+- Fixed unit in loading spinner
 
 ### Removed
 

--- a/config.go
+++ b/config.go
@@ -13,7 +13,6 @@ import (
 	"photofield/internal/layout"
 	"photofield/internal/render"
 	"photofield/tag"
-	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/imdario/mergo"
@@ -144,11 +143,7 @@ func loadConfig(dataDir string) (*AppConfig, error) {
 
 	for i := range collections {
 		collection := &collections[i]
-		collection.GenerateId()
-		collection.Layout = strings.ToUpper(collection.Layout)
-		if collection.Limit > 0 && collection.IndexLimit == 0 {
-			collection.IndexLimit = collection.Limit
-		}
+		collection.MakeValid()
 	}
 
 	// Override earlier collection with the same ID

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -106,6 +106,10 @@ media:
 
   # Set to true to not extract any metadata or colors from photos
   skip_load_info: false
+
+  # Skip printing the file count of collections at startup
+  # This can speed up startup time for large collections
+  skip_collection_counts: false
   
   caches:
     image:

--- a/internal/image/database.go
+++ b/internal/image/database.go
@@ -1672,8 +1672,8 @@ func (source *Database) GetTagsByName(tagNames []string) []tag.Tag {
 	return tags
 }
 
-func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoListResult, Dependencies) {
-	out := make(chan InfoListResult, 1000)
+func (source *Database) List(dirs []string, options ListOptions) (<-chan SourcedInfo, Dependencies) {
+	out := make(chan SourcedInfo, 1000)
 
 	tags := options.Query.QualifierValues("tag")
 	deps := Dependencies{
@@ -1685,9 +1685,6 @@ func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoLis
 
 	go func() {
 		defer metrics.Elapsed("list infos sqlite")()
-
-		conn := source.pool.Get(context.TODO())
-		defer source.pool.Put(conn)
 
 		sql := ""
 
@@ -1736,67 +1733,76 @@ func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoLis
 		}
 
 		sql += `
-			SELECT infos.id, width, height, orientation, color, created_at_unix, created_at_tz_offset, latitude, longitude`
-		if joinEmbeddings {
-			sql += `, inv_norm, embedding`
-		}
-		sql += `
-			FROM infos
+			SELECT * FROM (
 		`
-
-		if len(tags) > 0 {
-			for i := range tags {
-				sql += fmt.Sprintf(`
-					JOIN tag%[1]d ON id BETWEEN tag%[1]d.file_id AND tag%[1]d.file_id+tag%[1]d.len
-				`, i)
-			}
-		}
-
-		if joinEmbeddings {
-			sql += `
-				LEFT JOIN clip_emb ON clip_emb.file_id = id
-			`
-		}
-
-		sql += `
-			WHERE path_prefix_id IN (
-				SELECT id
-				FROM prefix
-				WHERE `
-
-		for i := range dirs {
-			sql += `str LIKE ? `
-			if i < len(dirs)-1 {
-				sql += "OR "
-			}
-		}
-
-		sql += `
-			)
-		`
-
-		if len(options.Extensions) > 0 {
-			sql += `
-			AND (
-			`
-			for i := range options.Extensions {
-				sql += `filename LIKE ? `
-				if i < len(options.Extensions)-1 {
-					sql += "OR "
-				}
-			}
-			sql += `
-			)
-			`
-		}
 
 		createdFrom, createdTo, createdErr := options.Query.QualifierDateRange("created")
-		if createdErr == nil {
+		prefixIds := source.GetPrefixIds(dirs)
+		for prefixIdx, _ := range prefixIds {
+
 			sql += `
-			AND created_at_unix >= ?
-			AND created_at_unix <= ?
+				SELECT infos.id, width, height, orientation, color, created_at_unix, created_at_tz_offset, latitude, longitude`
+			if joinEmbeddings {
+				sql += `, inv_norm, embedding`
+			}
+			sql += `
+				FROM infos
 			`
+
+			if len(tags) > 0 {
+				for i := range tags {
+					sql += fmt.Sprintf(`
+						JOIN tag%[1]d ON id BETWEEN tag%[1]d.file_id AND tag%[1]d.file_id+tag%[1]d.len
+					`, i)
+				}
+			}
+
+			if joinEmbeddings {
+				sql += `
+					LEFT JOIN clip_emb ON clip_emb.file_id = id
+				`
+			}
+
+			sql += `
+				WHERE true
+			`
+
+			if len(options.Extensions) > 0 {
+				sql += `
+					AND (
+					`
+				for i := range options.Extensions {
+					sql += fmt.Sprintf(
+						`filename LIKE :ext%[1]d `,
+						i,
+					)
+					if i < len(options.Extensions)-1 {
+						sql += "OR "
+					}
+				}
+				sql += `
+					)`
+			}
+			if createdErr == nil {
+				sql += `
+					AND created_at_unix >= :created_from
+					AND created_at_unix <= :created_to
+				`
+			}
+
+			sql += `
+				AND path_prefix_id = ?
+			`
+
+			if prefixIdx < len(prefixIds)-1 {
+				sql += `
+				UNION ALL
+				`
+			}
 		}
+
+		sql += `
+			)`
 
 		switch options.OrderBy {
 		case None:
@@ -1820,6 +1826,11 @@ func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoLis
 
 		sql += ";"
 
+		// println(sql)
+
+		conn := source.pool.Get(context.TODO())
+		defer source.pool.Put(conn)
+
 		stmt := conn.Prep(sql)
 		defer stmt.Reset()
 
@@ -1827,11 +1838,6 @@ func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoLis
 
 		for _, t := range tags {
 			stmt.BindText(bindIndex, t)
-			bindIndex++
-		}
-
-		for _, dir := range dirs {
-			stmt.BindText(bindIndex, dir+"%")
 			bindIndex++
 		}
 
@@ -1844,6 +1850,11 @@ func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoLis
 			stmt.BindInt64(bindIndex, createdFrom.Unix())
 			bindIndex++
 			stmt.BindInt64(bindIndex, createdTo.Unix())
+			bindIndex++
+		}
+
+		for _, prefixId := range prefixIds {
+			stmt.BindInt64(bindIndex, (int64)(prefixId))
 			bindIndex++
 		}
 
@@ -1861,27 +1872,20 @@ func (source *Database) List(dirs []string, options ListOptions) (<-chan InfoLis
 				break
 			}
 
-			var info InfoListResult
+			var info SourcedInfo
 			info.Id = (ImageId)(stmt.ColumnInt64(0))
 
 			info.Width = stmt.ColumnInt(1)
 			info.Height = stmt.ColumnInt(2)
-			info.SizeNull = stmt.ColumnType(1) == sqlite.TypeNull || stmt.ColumnType(2) == sqlite.TypeNull
-
 			info.Orientation = Orientation(stmt.ColumnInt(3))
-			info.OrientationNull = stmt.ColumnType(3) == sqlite.TypeNull
-
 			info.Color = (uint32)(stmt.ColumnInt64(4))
-			info.ColorNull = stmt.ColumnType(4) == sqlite.TypeNull
 
 			unix := stmt.ColumnInt64(5)
 			timezoneOffset := stmt.ColumnInt(6)
-
 			info.DateTime = time.Unix(unix, 0).In(time.FixedZone("", timezoneOffset*60))
-			info.DateTimeNull = stmt.ColumnType(5) == sqlite.TypeNull
 
-			info.LatLngNull = stmt.ColumnType(7) == sqlite.TypeNull || stmt.ColumnType(8) == sqlite.TypeNull
-			if info.LatLngNull {
+			latlngNull := stmt.ColumnType(7) == sqlite.TypeNull || stmt.ColumnType(8) == sqlite.TypeNull
+			if latlngNull {
 				info.LatLng = NaNLatLng()
 			} else {
 				info.LatLng = s2.LatLngFromDegrees(stmt.ColumnFloat(7), stmt.ColumnFloat(8))
@@ -2200,6 +2204,50 @@ func (source *Database) ListPaths(dirs []string, limit int) <-chan string {
 
 		close(out)
 	}()
+	return out
+}
+
+func (source *Database) GetPrefixIds(dirs []string) []int64 {
+
+	out := make([]int64, 0)
+
+	defer metrics.Elapsed("get prefix ids")()
+
+	conn := source.pool.Get(context.TODO())
+	defer source.pool.Put(conn)
+
+	sql := `
+			SELECT id
+			FROM prefix
+			WHERE
+		`
+
+	for i := range dirs {
+		sql += `str LIKE ? `
+		if i < len(dirs)-1 {
+			sql += "OR "
+		}
+	}
+
+	sql += ";"
+
+	stmt := conn.Prep(sql)
+	bindIndex := 1
+	defer stmt.Reset()
+
+	for _, dir := range dirs {
+		stmt.BindText(bindIndex, dir+"%")
+		bindIndex++
+	}
+
+	for {
+		if exists, err := stmt.Step(); err != nil {
+			log.Printf("Error getting prefixes: %s\n", err.Error())
+		} else if !exists {
+			break
+		}
+		out = append(out, stmt.ColumnInt64(0))
+	}
 	return out
 }
 

--- a/internal/image/search.go
+++ b/internal/image/search.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"log"
 	"math"
-	"path/filepath"
 	"photofield/internal/clip"
 	"photofield/internal/metrics"
 	"photofield/rangetree"
@@ -61,9 +60,6 @@ func (w similarityBatchWorker) close() {
 }
 
 func (source *Source) ListSimilar(dirs []string, embedding clip.Embedding, options ListOptions) <-chan SimilarityInfo {
-	for i := range dirs {
-		dirs[i] = filepath.FromSlash(dirs[i])
-	}
 	out := make(chan SimilarityInfo, 1000)
 	go func() {
 		defer metrics.Elapsed("list similar")()
@@ -242,9 +238,6 @@ func (source *Source) classifyEmbedding(timgs []taggedImage, emb clip.Embedding,
 }
 
 func (source *Source) ListKnn(dirs []string, options ListOptions) <-chan SourcedInfo {
-	for i := range dirs {
-		dirs[i] = filepath.FromSlash(dirs[i])
-	}
 	out := make(chan SourcedInfo, 1000)
 	go func() {
 		defer metrics.Elapsed("list knn")()

--- a/main.go
+++ b/main.go
@@ -1309,12 +1309,18 @@ func applyConfig(appConfig *AppConfig) {
 	for i := range collections {
 		collection := &collections[i]
 		collection.UpdateIndexedAt(imageSource)
-		collection.UpdateIndexedCount(imageSource)
+		if !appConfig.Media.SkipCollectionCounts {
+			collection.UpdateIndexedCount(imageSource)
+		}
 		indexedAgo := "N/A"
 		if collection.IndexedAt != nil {
 			indexedAgo = durafmt.Parse(time.Since(*collection.IndexedAt)).LimitFirstN(1).String()
 		}
-		log.Printf("  %v - %v files indexed %v ago", collection.Name, collection.IndexedCount, indexedAgo)
+		if appConfig.Media.SkipCollectionCounts {
+			log.Printf("  %v indexed %v ago", collection.Name, indexedAgo)
+		} else {
+			log.Printf("  %v - %v files indexed %v ago", collection.Name, collection.IndexedCount, indexedAgo)
+		}
 	}
 }
 
@@ -1347,7 +1353,6 @@ func main() {
 	benchCollectionId := flag.String("bench.collection", "vacation-photos", "id of the collection to benchmark")
 	benchSeed := flag.Int64("bench.seed", 123, "seed for random number generator")
 	benchSample := flag.Int("bench.sample", 10000, "number of images from the collection to use as a sample")
-	flag.Parse()
 
 	flag.Parse()
 

--- a/ui/src/components/MapViewer.vue
+++ b/ui/src/components/MapViewer.vue
@@ -31,7 +31,7 @@
         scene?.load_count !== undefined ?
           scene?.load_count : scene?.file_count
       "
-      :unit="scene?.load_unit || 'files'"
+      :unit="scene?.load_unit"
       :speed="loadSpeed"
       :divider="10000"
       :loading="scene?.loading"

--- a/ui/src/components/Spinner.vue
+++ b/ui/src/components/Spinner.vue
@@ -2,7 +2,7 @@
   <div class="spinner" :class="{ hidden: !loading || !visible, removed: !visible }">
     <div class="label">
       <template v-if="loading && total == 0">Loading</template>
-      <template v-else-if="loading">{{ interpolatedTotal && Math.round(interpolatedTotal).toLocaleString() }} {{unit}}</template>
+      <template v-else-if="loading">{{ (interpolatedTotal && Math.round(interpolatedTotal).toLocaleString()) || 0 }} {{unit || 'files'}}</template>
       <template v-else>{{ total && total.toLocaleString() }} files</template>
     </div>
     <svg :viewBox="`0 0 ${width} ${height}`" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Fixes a few smaller and bigger issues when it comes to performance loading 100k+ file collections.

## Improvements

Tests with collections made from 10M+ dummy files reveal the following improvements. Numbers based on an older i7-5820K 6-Core desktop CPU.
- 10M files in 1 dir
  - **Before:** loading starts after 15 seconds
  - **After:** loading starts in under 1 second
- 10M files in 3000 dirs
  - **Before:** loading starts after 38 seconds
  - **After:** loading starts in under 1 second

## Changes

- Fix the loading spinner only showing the number without "files"
- Add `skip_collection_counts` to avoid showing collection counts on startup, which can speed it up in case of large collections
- Refactor the way collection loading works to avoid some slow operations
  - Reduce the amount of objects created leading to less garbage having to be collected
  - Avoid SQLite sorting the collection in memory, leading to faster big collection loads
  - Fix large collections breaking transformation matrix inversion, fixes #54
- Fixed a bug where collections with dirs that are a prefix of other dirs would in some cases erroneously also list files in these other dirs (e.g. `/vacation` would include `/vacation2` or `/vacation-eu`)

## Limitations / Breaking changes

This change introduces a limitation of **max 50000 directories** that can be sourced in a single collection. Considering the previously long loading time of such collections, this is probably not a big concern. If you hit this limitation, please let me know!