### PR TITLE
Fix rescan file counting

### DIFF
--- a/ui/src/components/CollectionSettings.vue
+++ b/ui/src/components/CollectionSettings.vue
@@ -39,7 +39,7 @@ const {
 const fileCount = computed(() => {
   if (collection.value) {
     for (const task of tasks.value) {
-      if (task.type != "INDEX") continue;
+      if (task.type != "INDEX_FILES") continue;
       if (task.collection_id != collection.value.id) continue;
       return task.done.toLocaleString();
     }


### PR DESCRIPTION
Fix a bug that prevented from files being shown counted live while a rescan was in progress.