### PR TITLE
Add basic photo details including web & app gestures

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -589,13 +589,13 @@ components:
       content:
         "image/*":
           schema:
-            $ref: "#/components/schemas/File"
+            $ref: "#/components/schemas/FileBinary"
     FileNotFound:
       description: Raw binary file (image or video)
       content:
         "image/*":
           schema:
-            $ref: "#/components/schemas/File"
+            $ref: "#/components/schemas/FileBinary"
 
   parameters:
     SearchParam:
@@ -771,9 +771,65 @@ components:
     RegionData:
       type: object
 
-    File:
+    FileBinary:
       type: string
       format: binary
+
+    File:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/FileId"
+        path:
+          type: string
+          example: "photos/vacation/IMG_1234.JPG"
+        filename:
+          type: string
+          example: "IMG_1234.JPG"
+        extension:
+          type: string
+          example: ".JPG"
+        video:
+          type: boolean
+          example: false
+        width:
+          type: integer
+          example: 5472
+        height:
+          type: integer
+          example: 3648
+        created_at:
+          type: string
+          format: date-time
+          example: "2024-04-01T19:12:08-03:59"
+        thumbnails:
+          type: array
+          items:
+            $ref: "#/components/schemas/Thumbnail"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+
+    Thumbnail:
+      type: object
+      required:
+        - name
+        - display_name
+        - width
+        - height
+        - filename
+      properties:
+        name:
+          type: string
+        display_name:
+          type: string
+        width:
+          type: integer
+        height:
+          type: integer
+        filename:
+          type: string
 
     SceneParams:
       type: object
@@ -840,6 +896,12 @@ components:
           type: string
         name:
           type: string
+        updated_at:
+          type: string
+          format: date-time
+        etag:
+          type: string
+          description: ETag for optimistic concurrency control
 
           
     TaskType:

--- a/internal/openapi/api.gen.go
+++ b/internal/openapi/api.gen.go
@@ -90,8 +90,8 @@ type DocsCapability struct {
 	Url string `json:"url"`
 }
 
-// File defines model for File.
-type File string
+// FileBinary defines model for FileBinary.
+type FileBinary string
 
 // FileId defines model for FileId.
 type FileId int
@@ -168,8 +168,11 @@ type Sort string
 
 // Tag defines model for Tag.
 type Tag struct {
-	Id   *string `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	// ETag for optimistic concurrency control
+	Etag      *string    `json:"etag,omitempty"`
+	Id        *string    `json:"id,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // Perform the specified tag operation for the specified files.

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -46,6 +46,7 @@
       <template #toolbar="{ toolbarItemClass }">
 
         <collection-panel
+          v-if="!immersive"
           class="collection-panel"
           :class="{ hidden: !collectionExpanded }"
           ref="collectionPanel"

--- a/ui/src/components/Controls.vue
+++ b/ui/src/components/Controls.vue
@@ -9,6 +9,14 @@
     <div class="toolbar">
       <!-- <ui-icon light class="icon" size="32" @click="$event => download()">download</ui-icon> -->
       <ui-icon
+        light
+        class="icon"
+        size="32"
+        @click="emit('info')"
+      >
+        info_outline
+      </ui-icon>
+      <ui-icon
         v-if="tagsSupported"
         light
         class="icon"
@@ -76,6 +84,7 @@ const fileId = computed(() => region.value?.data?.id);
 const emit = defineEmits([
   "navigate",
   "exit",
+  "info",
 ]);
 
 const { idle } = useIdle(5000, {

--- a/ui/src/components/DetailItem.vue
+++ b/ui/src/components/DetailItem.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="detail-item">
+    <dt>
+      <ui-skeleton
+        :loading="loading"
+        :active="true"
+        class="icon"
+        :avatar="{ size: 24 }"
+        :title="false"
+        :paragraph="false"
+      >
+        <ui-icon class="icon" :outlined="outlined">{{ icon }}</ui-icon>
+      </ui-skeleton>
+    </dt>
+    <dd class="content">
+      <ui-skeleton
+        :loading="loading"
+        :active="true"
+        :title="false"
+        :paragraph="{ rows: 2 }"
+      >
+        <span :class="$tt('subtitle1')">{{ title }}</span>
+        <div>
+          <span
+            v-for="sub in subtitles"
+            :key="sub"
+            :class="[$tt('subtitle2'), 'sub']"
+          >
+            {{ sub }}
+          </span>
+        </div>
+      </ui-skeleton>
+    </dd>
+  </div>
+</template>
+
+<script setup>
+
+const props = defineProps({
+    icon: String,
+    title: String,
+    subtitles: Array,
+    outlined: Boolean,
+    loading: Boolean,
+});
+
+</script>
+
+<style scoped>
+
+.detail-item {
+  display: flex;
+  padding: 18px 24px ;
+  align-items: top;
+}
+
+.icon {
+  margin-top: 1px;
+  width: 24px;
+  height: 24px;
+  color: var(--mdc-theme-text-primary-on-background);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  margin-left: 16px;
+  width: 100%;
+}
+
+.sub {
+  font-weight: 400;
+  margin-right: 12px;
+  color: var(--mdc-theme-text-secondary-on-background);
+}
+
+</style>

--- a/ui/src/components/Map.vue
+++ b/ui/src/components/Map.vue
@@ -1,0 +1,142 @@
+<template>
+  <div>
+    <ui-skeleton
+      :loading="loading"
+      :active="true"
+      :avatar="false"
+      :title="false"
+      :paragraph="{ width: '100%', rows: 1 }"
+    >
+    </ui-skeleton>
+    <div v-if="!consent" class="consent">
+      <ui-alert state="info">
+        Displaying the map will share location data with <a href="https://www.openstreetmap.org/" target="_blank">OpenStreetMap</a>.
+        <ui-button @click="consent = true">I agree, show the map</ui-button>
+      </ui-alert>
+    </div>
+    <div
+      v-if="consent"
+      v-show="!loading"
+      class="map-container"
+      ref="mapContainer"
+    ></div>
+  </div>
+</template>
+
+<script setup>
+import { useStorage } from '@vueuse/core';
+import { Feature } from 'ol';
+import { Point } from 'ol/geom';
+import TileLayer from 'ol/layer/Tile';
+import VectorLayer from 'ol/layer/Vector';
+import Map from 'ol/Map';
+import { fromLonLat, get as getProjection, toLonLat } from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
+import Style from 'ol/style/Style';
+import Text from 'ol/style/Text';
+import View from 'ol/View';
+import { onMounted, ref, toRefs, watch } from 'vue';
+
+const proj = getProjection("EPSG:3857");
+
+const props = defineProps({
+  geoview: Array,
+  loading: Boolean,
+});
+
+const {
+  geoview,
+  loading,
+} = toRefs(props);
+
+const mapContainer = ref(null);
+const map = ref(null); // Add a ref for the map variable
+
+const consent = useStorage('map-consent', false);
+
+watch(mapContainer, (newValue, oldValue) => {
+  if (newValue === oldValue) return;
+  if (!newValue) return;
+  initOpenLayers(newValue);
+});
+
+function setGeoview(geoview) {
+  if (!map.value || !geoview) return;
+  const view = map.value.getView();
+  view.setCenter(fromLonLat(geoview, proj));
+  view.setZoom(geoview[2]);
+  const source = map.value.getLayers().getArray()[1].getSource();
+  const feature = source.getFeatures()[0];
+  feature.setGeometry(new Point(fromLonLat(geoview, proj)));
+}
+
+watch(geoview, (newValue, oldValue) => {
+  if (newValue === oldValue) return;
+  if (!newValue) return;
+  if (oldValue && newValue[0] === oldValue[0] && newValue[1] === oldValue[1] && newValue[2] === oldValue[2]) return;
+  setGeoview(newValue);
+});
+
+function initOpenLayers(element) {
+  map.value = new Map({
+    target: element,
+    layers: [
+      new TileLayer({
+        source: new OSM(),
+      }),
+    ],
+    view: new View(),
+  });
+
+  const source = new VectorSource();
+  const feature = new Feature();
+  feature.setStyle(new Style({
+    text: new Text({
+      text: 'place',
+      font: "40px Material Icons",
+    }),
+  }));
+  feature.on()
+  source.addFeature(feature);
+  
+  const markerLayer = new VectorLayer({
+    source,
+  });
+  map.value.addLayer(markerLayer);
+
+  map.value.on('click', function (event) {
+    map.value.forEachFeatureAtPixel(event.pixel, function (feature) {
+      const coords = feature.getGeometry().getCoordinates();
+      const lonlat = toLonLat(coords, proj);
+      window.open(`https://www.google.com/maps/search/?api=1&query=${lonlat[1]},${lonlat[0]}`, '_blank');
+    })
+  });
+
+  map.value.on('pointermove', function (event) {
+    const hit = map.value.hasFeatureAtPixel(event.pixel);
+    mapContainer.value.style.cursor = hit ? 'pointer' : '';
+  });
+
+  setGeoview(geoview.value);
+}
+</script>
+
+<style scoped>
+.map-container, :deep(.mdc-skeleton-paragraph > li), .consent {
+  width: 100%;
+  height: 200px;
+  box-sizing: border-box;
+}
+
+.consent {
+  padding: 10px;
+  vertical-align: center;
+  text-align: center;
+}
+
+.consent button {
+  margin-top: 10px;
+}
+
+</style>

--- a/ui/src/components/MapViewer.vue
+++ b/ui/src/components/MapViewer.vue
@@ -77,7 +77,6 @@ const props = defineProps({
   search: String,
   selectTag: Object,
   debug: Object,
-  fullpage: Boolean,
   scrollbar: Object,
   tweaks: String,
 });
@@ -92,6 +91,7 @@ const emit = defineEmits({
   selectTag: null,
   search: null,
   viewer: null,
+  swipeUp: null,
 })
 
 const {
@@ -271,6 +271,10 @@ const onNav = async (event) => {
     await exit();
     return;
   }
+  if (event.zoom > 0) {
+    emit("swipeUp");
+    return;
+  }
   zoomOut();
 }
 
@@ -326,7 +330,7 @@ defineExpose({
 
 .map .viewer {
   position: absolute;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   /* Fix for mobile browsers */
   height: calc(var(--vh, 1vh) * 100);

--- a/ui/src/components/PhotoDetails.vue
+++ b/ui/src/components/PhotoDetails.vue
@@ -1,0 +1,207 @@
+<template>
+  <div class="photo-details" ref="container">
+    <div class="background" ref="background"></div>
+    <div class="bar swipeable">
+      <ui-icon-button
+        icon="close"
+        outlined
+        @click="$emit('close')"
+      >
+      </ui-icon-button>
+      <h2
+        :class="$tt('headline5')"
+      >
+        Info
+      </h2>
+    </div>
+    <dl class="contents" v-if="photo">
+      <tags
+        :region="region"
+        :tags="region?.data?.tags"
+        :loading="loading"
+      ></tags>
+      <detail-item
+        icon="today"
+        class="swipeable"
+        :loading="loading"
+        :title="date"
+        :subtitles="[time, timezone]"
+      ></detail-item>
+      <detail-item
+        icon="photo"
+        class="swipeable"
+        :loading="loading"
+        :title="photo.filename"
+        :subtitles="[megapixels, dimensions]"
+        outlined
+      ></detail-item>
+      <detail-item
+        v-if="photo.location"
+        icon="room"
+        class="swipeable"
+        :loading="loading"
+        :title="photo.location"
+        outlined
+      ></detail-item>
+      <Map
+        v-if="geoview"
+        :loading="loading"
+        class="map"
+        :geoview="geoview"
+      ></Map>
+      <!-- <div class="thumbnails">
+        <a
+          class="thumbnail"
+          v-for="thumb in region.data?.thumbnails"
+          :key="thumb.name"
+          :href="getThumbnailUrl(region.data.id, thumb.name, thumb.filename)"
+          :title="thumb.width + ' x ' + thumb.height + ' (' + thumb.display_name + ')'"
+          target="_blank"
+        >
+          {{ thumb.width }}
+        </a>
+      </div> -->
+    </dl>
+  </div>
+</template>
+
+<script setup>
+import { useSwipe } from '@vueuse/core';
+import dateFormat from 'date-fns/format';
+import dateParseISO from 'date-fns/parseISO';
+import { computed, ref, toRefs } from 'vue';
+import { useRegion } from '../use';
+import DetailItem from './DetailItem.vue';
+import Map from './Map.vue';
+import Tags from './Tags.vue';
+
+const props = defineProps({
+  scene: Object,
+  regionId: String,
+});
+
+const emit = defineEmits([
+  'close',
+]);
+
+const {
+  scene,
+  regionId,
+} = toRefs(props);
+
+const background = ref(null);
+const container = ref(null);
+
+useSwipe(container, {
+  onSwipeEnd(event, direction) {
+    if (direction != "DOWN") return;
+    if (!event.target.closest('.swipeable')) {
+      return;
+    }
+    emit("close");
+  },
+});
+
+const {
+  region,
+  loading,
+} = useRegion({ scene, id: regionId })
+
+const createdAt = computed(() => {
+  const at = region.value?.data?.created_at;
+  if (!at) return null;
+  return dateParseISO(at);
+});
+
+const photo = computed(() => {
+  return region.value?.data;
+});
+
+const date = computed(() => {
+  if (!createdAt.value) return "";
+  return dateFormat(createdAt.value, "MMM d");
+});
+
+const time = computed(() => {
+  if (!createdAt.value) return "";
+  return dateFormat(createdAt.value, "EEE, h:mm aa");
+});
+
+const timezone = computed(() => {
+  if (!createdAt.value) return "";
+  return dateFormat(createdAt.value, "OOOO");
+});
+
+const megapixels = computed(() => {
+  const width = photo.value?.width;
+  const height = photo.value?.height;
+  if (!width || !height) return "";
+  return (width * height / 1e6).toFixed(1) + " MP";
+});
+
+const dimensions = computed(() => {
+  const width = photo.value?.width;
+  const height = photo.value?.height;
+  if (!width || !height) return "";
+  return width + " × " + height;
+});
+
+const geoview = computed(() => {
+  if (!photo.value?.latlng) return null;
+  return [
+    photo.value.latlng.lng,
+    photo.value.latlng.lat,
+    12,
+  ];
+});
+
+</script>
+
+<style scoped>
+
+.photo-details {
+  background-color: white;
+  max-width: 360px;
+  max-height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.background {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}
+
+.bar {
+  padding: 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.thumbnails {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 12px;
+}
+
+.thumbnail {
+  font-size: 0.8em;
+  padding: 10px 6px;
+  text-decoration: none;
+  color: var(--mdc-theme-text-primary-on-background);
+}
+
+
+.tags {
+  padding: 0 18px;
+  box-sizing: border-box;
+}
+
+.bar > h2 {
+  margin: 0;
+}
+
+</style>

--- a/ui/src/components/PhotoDetails.vue
+++ b/ui/src/components/PhotoDetails.vue
@@ -16,6 +16,7 @@
     </div>
     <dl class="contents" v-if="photo">
       <tags
+        v-if="tagsSupported"
         :region="region"
         :tags="region?.data?.tags"
         :loading="loading"
@@ -74,6 +75,7 @@ import { useRegion } from '../use';
 import DetailItem from './DetailItem.vue';
 import Map from './Map.vue';
 import Tags from './Tags.vue';
+import { useApi } from '../api';
 
 const props = defineProps({
   scene: Object,
@@ -88,6 +90,9 @@ const {
   scene,
   regionId,
 } = toRefs(props);
+
+const { data: capabilities } = useApi(() => "/capabilities");
+const tagsSupported = computed(() => capabilities.value?.tags?.supported);
 
 const background = ref(null);
 const container = ref(null);

--- a/ui/src/components/ScrollViewer.vue
+++ b/ui/src/components/ScrollViewer.vue
@@ -107,6 +107,7 @@ const emit = defineEmits({
   search: null,
   elementView: null,
   viewer: null,
+  swipeUp: null,
 })
 
 const {
@@ -364,6 +365,10 @@ const onNav = async (event) => {
     await exit();
     return;
   }
+  if (event.zoom > 0) {
+    emit("swipeUp");
+    return;
+  }
   zoomOut();
 }
 
@@ -452,7 +457,7 @@ defineExpose({
 
 .scroll.fullpage .viewer {
   position: absolute;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   /* Fix for mobile browsers */
   height: calc(var(--vh, 1vh) * 100);

--- a/ui/src/components/Tags.vue
+++ b/ui/src/components/Tags.vue
@@ -21,7 +21,7 @@
       tag-position="bottom"
       track-by="name"
       label="name"
-      :loading="loading"
+      :loading="loading || searching"
       :close-on-select="false"
       :clear-on-select="false"
       placeholder="Add tags"
@@ -68,6 +68,7 @@ const props = defineProps({
   tags: Array,
   readonly: Boolean,
   message: String,
+  loading: Boolean,
 });
 
 const emit = defineEmits([
@@ -80,12 +81,12 @@ const {
 } = toRefs(props);
 
 const options = ref([])
-const loading = ref(false);
+const searching = ref(false);
 
 const onSearch = async (query) => {
-  loading.value = true;
+  searching.value = true;
   const tags = await get(`/tags?${qs.stringify({ q: query })}`);
-  loading.value = false;
+  searching.value = false;
   options.value = tags?.items;
 }
 

--- a/ui/src/components/TileViewer.vue
+++ b/ui/src/components/TileViewer.vue
@@ -25,7 +25,7 @@ import Projection from 'ol/proj/Projection';
 import { easeIn, easeOut, linear } from 'ol/easing';
 import { defaults as defaultInteractions, DragBox, DragPan, MouseWheelZoom } from 'ol/interaction';
 import { defaults as defaultControls } from 'ol/control';
-import {MAC} from 'ol/src/has.js';
+import {MAC} from 'ol/has';
 import Kinetic from 'ol/Kinetic';
 import { get as getProjection } from 'ol/proj';
 import { getBottomLeft, getTopLeft, getTopRight, getBottomRight } from 'ol/extent';
@@ -132,6 +132,15 @@ export default {
       if (newGeo != oldGeo) {
         this.reset();
       }
+    },
+
+    viewport: {
+      handler(viewport) {
+        if (!viewport) return;
+        if (!this.geo) return;
+        this.reset();
+      },
+      deep: true,
     },
 
     tileSize() {
@@ -515,6 +524,7 @@ export default {
       } else if (this.view) {
         this.setView(this.view);
       }
+      this.initZoom = this.focusZoom;
 
       this.setKinetic(this.kinetic);
       this.$emit("viewer", this.map);
@@ -648,6 +658,12 @@ export default {
         });
         return;
       }
+      if (event.y > 0) {
+        this.$emit("nav", {
+          zoom: 1,
+        });
+        return;
+      }
       if (event.interrupted) {
         this.navOnZoom(event);
         return;
@@ -661,6 +677,9 @@ export default {
     navOnZoom() {
       const ratio = this.focusZoom;
       if (Math.abs(1 - ratio) < 1e-4) {
+        return;
+      }
+      if (Math.abs(this.initZoom - this.focusZoom) < 1e-4) {
         return;
       }
       if (ratio < 0.8) {

--- a/ui/src/use.js
+++ b/ui/src/use.js
@@ -141,6 +141,7 @@ export function useRegion({ scene, id }) {
 
   return {
     region,
+    loading: isValidating,
     mutate,
   };
 }


### PR DESCRIPTION
This pull request introduces the photo details sidebar that can be shown by using the (i) button on the zoomed photo page. It only has a few basic details for now, like date, tags (if enabled), photo name & dimensions, and location.