### PR TITLE
Open in album

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -329,6 +329,15 @@ paths:
             type: number
             example: 200
 
+        - name: closest
+          in: query
+          description: |
+            If true, return the closest region to the specified `x` and `y` coordinates.
+            The `w` and `h` parameters are ignored in this case.
+          schema:
+            type: boolean
+            example: false
+
         - name: limit
           in: query
           schema:

--- a/internal/image/database.go
+++ b/internal/image/database.go
@@ -1780,6 +1780,11 @@ func (source *Database) listWithPrefixIds(prefixIds []int64, options ListOptions
 		},
 	}
 
+	if len(prefixIds) == 0 {
+		close(out)
+		return out, deps
+	}
+
 	go func() {
 		if options.Batch == 0 {
 			defer metrics.Elapsed("list infos sqlite")()

--- a/internal/layout/common.go
+++ b/internal/layout/common.go
@@ -268,6 +268,14 @@ func (regionSource PhotoRegionSource) GetRegionById(id int, scene *render.Scene,
 	return regionSource.getRegionFromPhoto(id, &photo, scene, regionConfig)
 }
 
+func (regionSource PhotoRegionSource) GetRegionClosestTo(p render.Point, scene *render.Scene, regionConfig render.RegionConfig) (region render.Region, ok bool) {
+	photo, ok := scene.GetClosestPhotoRef(p)
+	if !ok {
+		return render.Region{}, false
+	}
+	return regionSource.getRegionFromPhoto(1+photo.Index, photo.Photo, scene, regionConfig), true
+}
+
 func layoutFitRow(row []render.Photo, bounds render.Rect, imageSpacing float64) float64 {
 	count := len(row)
 	if count == 0 {

--- a/internal/openapi/api.gen.go
+++ b/internal/openapi/api.gen.go
@@ -273,7 +273,11 @@ type GetScenesSceneIdRegionsParams struct {
 	Y      *float32 `json:"y,omitempty"`
 	W      *float32 `json:"w,omitempty"`
 	H      *float32 `json:"h,omitempty"`
-	Limit  *Limit   `json:"limit,omitempty"`
+
+	// If true, return the closest region to the specified `x` and `y` coordinates.
+	// The `w` and `h` parameters are ignored in this case.
+	Closest *bool  `json:"closest,omitempty"`
+	Limit   *Limit `json:"limit,omitempty"`
 }
 
 // GetScenesSceneIdTilesParams defines parameters for GetScenesSceneIdTiles.
@@ -841,6 +845,17 @@ func (siw *ServerInterfaceWrapper) GetScenesSceneIdRegions(w http.ResponseWriter
 	err = runtime.BindQueryParameter("form", true, false, "h", r.URL.Query(), &params.H)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid format for parameter h: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "closest" -------------
+	if paramValue := r.URL.Query().Get("closest"); paramValue != "" {
+
+	}
+
+	err = runtime.BindQueryParameter("form", true, false, "closest", r.URL.Query(), &params.Closest)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid format for parameter closest: %s", err), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/render/photo.go
+++ b/internal/render/photo.go
@@ -173,7 +173,7 @@ func (photo *Photo) Draw(config *Render, scene *Scene, c *canvas.Context, scales
 	}
 
 	if !drawn {
-		if len(errs) > 0 {
+		if config.DebugThumbnails && len(errs) > 0 {
 			log.Printf("Unable to draw photo %v: %v", photo.Id, errs)
 		}
 

--- a/main.go
+++ b/main.go
@@ -855,6 +855,27 @@ func (*Api) GetScenesSceneIdRegions(w http.ResponseWriter, r *http.Request, scen
 			return
 		}
 		regions = scene.GetRegionsByImageId(image.ImageId(*params.FileId), limit)
+	} else if params.Closest != nil && *params.Closest {
+		if params.X == nil || params.Y == nil {
+			problem(w, r, http.StatusBadRequest, "x and y required")
+			return
+		}
+		if params.Limit == nil || *params.Limit != 1 {
+			problem(w, r, http.StatusBadRequest, "limit must be set to 1")
+			return
+		}
+
+		p := render.Point{
+			X: float64(*params.X),
+			Y: float64(*params.Y),
+		}
+
+		region, ok := scene.GetRegionClosestTo(p)
+		if !ok {
+			regions = []render.Region{}
+		} else {
+			regions = []render.Region{region}
+		}
 	} else {
 		if params.X == nil || params.Y == nil || params.W == nil || params.H == nil {
 			problem(w, r, http.StatusBadRequest, "bounds or file_id required")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "fast-deep-equal": "^3.1.3",
         "kalmanjs": "^1.1.0",
         "ol": "^6.15.1",
-        "overlayscrollbars": "^1.13.2",
+        "overlayscrollbars": "^1.13.3",
         "overlayscrollbars-vue": "^0.3.0",
         "plyr": "^3.7.2",
         "qs": "^6.11.0",
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/overlayscrollbars": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.2.tgz",
-      "integrity": "sha512-xk9eJ8fpuh28WABSDpMpOv90aDQk+x5wLeqU4AGbJg56eGLeKxVPQzMxeX6+BM2dsIIOcBj3Fwvn8A0EzhHN3g=="
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.3.tgz",
+      "integrity": "sha512-1nB/B5kaakJuHXaLXLRK0bUIilWhUGT6q5g+l2s5vqYdLle/sd0kscBHkQC1kuuDg9p9WR4MTdySDOPbeL/86g=="
     },
     "node_modules/overlayscrollbars-vue": {
       "version": "0.3.0",
@@ -5823,9 +5823,9 @@
       }
     },
     "overlayscrollbars": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.2.tgz",
-      "integrity": "sha512-xk9eJ8fpuh28WABSDpMpOv90aDQk+x5wLeqU4AGbJg56eGLeKxVPQzMxeX6+BM2dsIIOcBj3Fwvn8A0EzhHN3g=="
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.3.tgz",
+      "integrity": "sha512-1nB/B5kaakJuHXaLXLRK0bUIilWhUGT6q5g+l2s5vqYdLle/sd0kscBHkQC1kuuDg9p9WR4MTdySDOPbeL/86g=="
     },
     "overlayscrollbars-vue": {
       "version": "0.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
     "fast-deep-equal": "^3.1.3",
     "kalmanjs": "^1.1.0",
     "ol": "^6.15.1",
-    "overlayscrollbars": "^1.13.2",
+    "overlayscrollbars": "^1.13.3",
     "overlayscrollbars-vue": "^0.3.0",
     "plyr": "^3.7.2",
     "qs": "^6.11.0",

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -105,6 +105,26 @@ export async function getCenterRegion(sceneId, x, y, w, h) {
   return minRegion;
 }
 
+export async function getRegionClosestTo(sceneId, x, y, w, h, rx, ry) {
+  const regions = await getRegions(sceneId, x, y, w, h);
+  if (!regions) return null;
+  let minDistSq = Infinity;
+  let minRegion = null;
+  for (let i = 0; i < regions.length; i++) {
+    const region = regions[i];
+    const rcx = region.bounds.x + region.bounds.w*0.5;
+    const rcy = region.bounds.y + region.bounds.h*0.5;
+    const dx = rcx - rx;
+    const dy = rcy - ry;
+    const distSq = dx*dx + dy*dy;
+    if (distSq < minDistSq) {
+      minDistSq = distSq;
+      minRegion = region;
+    }
+  }
+  return minRegion;
+}
+
 export async function getCollections() {
   return get(`/collections`);
 }

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -79,6 +79,13 @@ export async function getRegionsWithFileId(sceneId, id) {
   return response.items;
 }
 
+export async function getRegionClosestTo(sceneId, x, y) {
+  if (!sceneId) return null;
+  const response = await get(`/scenes/${sceneId}/regions?x=${x}&y=${y}&closest=true&limit=1`);
+  if (!response.items?.length) return null;
+  return response.items[0];
+}
+
 export async function getRegion(sceneId, id) {
   return get(`/scenes/${sceneId}/regions/${id}`);
 }
@@ -96,26 +103,6 @@ export async function getCenterRegion(sceneId, x, y, w, h) {
     const rcy = region.bounds.y + region.bounds.h*0.5;
     const dx = rcx - cx;
     const dy = rcy - cy;
-    const distSq = dx*dx + dy*dy;
-    if (distSq < minDistSq) {
-      minDistSq = distSq;
-      minRegion = region;
-    }
-  }
-  return minRegion;
-}
-
-export async function getRegionClosestTo(sceneId, x, y, w, h, rx, ry) {
-  const regions = await getRegions(sceneId, x, y, w, h);
-  if (!regions) return null;
-  let minDistSq = Infinity;
-  let minRegion = null;
-  for (let i = 0; i < regions.length; i++) {
-    const region = regions[i];
-    const rcx = region.bounds.x + region.bounds.w*0.5;
-    const rcy = region.bounds.y + region.bounds.h*0.5;
-    const dx = rcx - rx;
-    const dy = rcy - ry;
     const distSq = dx*dx + dy*dy;
     if (distSq < minDistSq) {
       minDistSq = distSq;

--- a/ui/src/components/CollectionView.vue
+++ b/ui/src/components/CollectionView.vue
@@ -40,6 +40,7 @@
       :interactive="interactive"
       :collectionId="collection && collectionId"
       :regionId="regionId"
+      :focusFileId="focusFileId"
       :layout="layout"
       :sort="sort"
       :imageHeight="imageHeight"
@@ -50,6 +51,7 @@
       :scrollbar="scrollbar"
       :selectTag="selectTagId && selectTag"
       @selectTag="onSelectTag"
+      @focusFileId="onFocusFileId"
       @region="onRegion"
       @elementView="lastView = $event"
       @scene="scrollScene = $event"
@@ -213,6 +215,19 @@ const selectTagId = computed(() => {
   return route.query.select_tag || undefined;
 })
 
+const focusFileId = computed(() => {
+  return route.query.f || undefined;
+})
+
+async function onFocusFileId(id) {
+  await router.replace({
+    query: {
+      ...route.query,
+      f: id || undefined,
+    }
+  });
+}
+
 const {
   data: selectTag,
   mutate: selectTagMutate,
@@ -313,8 +328,8 @@ const onRegion = async (region) => {
 }
 
 .controls, .viewer {
-  transition: transform 0.2s;
-  transform: translateY(0);
+  transition: top 0.2s;
+  top: 0;
 }
 
 .showDetails .controls, .showDetails .viewer {
@@ -341,13 +356,13 @@ const onRegion = async (region) => {
 @media (max-width: 700px) {
 
   .controls, .viewer {
-    transition: transform 0.2s;
-    transform: translateY(0);
+    transition: top 0.2s;
+    top: 0;
   }
 
   .showDetails .controls, .showDetails .viewer {
     max-width: 100vw;
-    transform: translateY(-100vh);
+    top: -100vh;
   }
 
   .details {

--- a/ui/src/components/RegionMenu.vue
+++ b/ui/src/components/RegionMenu.vue
@@ -36,6 +36,7 @@
         <ui-nav-item
           v-if="albumUrl"
           :href="albumUrl"
+          target="_blank"
           @click="$emit('close')"
         >
           Open Image in Album

--- a/ui/src/components/RegionMenu.vue
+++ b/ui/src/components/RegionMenu.vue
@@ -33,6 +33,13 @@
         >
           Open Image in New Tab
         </ui-nav-item>
+        <ui-nav-item
+          v-if="albumUrl"
+          :href="albumUrl"
+          @click="$emit('close')"
+        >
+          Open Image in Album
+        </ui-nav-item>
         <ui-item @click="copyImage()">
           Copy Image
         </ui-item>
@@ -69,8 +76,9 @@ import copyImg from 'copy-image-clipboard';
 import TileViewer from './TileViewer.vue';
 import ExpandButton from './ExpandButton.vue';
 import { getFileUrl, getThumbnailUrl } from '../api';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useViewport } from '../use';
+import { useRoute } from 'vue-router';
 
 export default {
   props: ["region", "scene", "flipX", "flipY", "tileSize"],
@@ -82,12 +90,24 @@ export default {
       expanded: false,
     }
   },
-  setup() {
+  setup(props) {
     const viewer = ref(null);
     const viewport = useViewport(viewer);
+    const route = useRoute();
+    const albumUrl = computed(() => {
+      const fileId = props.region?.data?.id;
+      if (!fileId) return null;
+      const url = new URL(route.fullPath, window.location.origin);
+      url.searchParams.set("f", fileId);
+      url.searchParams.set("layout", "ALBUM");
+      url.searchParams.delete("search");
+      url.pathname = url.pathname.replace(/(.*\/collections\/[^/]+)\/.*$/, "$1");
+      return url.toString();
+    });
     return {
       viewer,
       viewport,
+      albumUrl,
     }
   },
   computed: {

--- a/ui/src/components/ScrollViewer.vue
+++ b/ui/src/components/ScrollViewer.vue
@@ -305,7 +305,6 @@ watchDebounced(scrollY, async (sy) => {
   const { x, y, w, h } = view.value;
   const center = await getRegionClosestTo(
     scene.value.id,
-    x, y, w, h,
     x, y + h * focusScreenRatioY,
   );
   const fileId = center?.data?.id;

--- a/ui/src/use.js
+++ b/ui/src/use.js
@@ -264,8 +264,8 @@ export function useSeekableRegion({ scene, collectionId, regionId }) {
 export function useViewport(element) {
   const viewport = useElementSize(element);
   return {
-    width: refDebounced(viewport.width, 2000),
-    height: refDebounced(viewport.height, 2000),
+    width: refDebounced(viewport.width, 500),
+    height: refDebounced(viewport.height, 500),
   }
 }
 

--- a/ui/src/use.js
+++ b/ui/src/use.js
@@ -34,6 +34,8 @@ export function useScrollbar(scrollbar, sleep) {
     if (!scrollbar.value) return;
     
     const scroll = scrollbar.value.scroll();
+    if (scroll.max.y === 0) return;
+
     let r = scroll.ratio.y;
 
     if (lastScrollPixels.value !== null) {
@@ -65,6 +67,7 @@ export function useScrollbar(scrollbar, sleep) {
 
   const onContentSizeChanged = () => {
     scrollToRatio(ratio.value);
+    onScroll();
   }
 
   watchEffect(() => {
@@ -261,8 +264,8 @@ export function useSeekableRegion({ scene, collectionId, regionId }) {
 export function useViewport(element) {
   const viewport = useElementSize(element);
   return {
-    width: refDebounced(viewport.width, 200),
-    height: refDebounced(viewport.height, 200),
+    width: refDebounced(viewport.width, 2000),
+    height: refDebounced(viewport.height, 2000),
   }
 }
 


### PR DESCRIPTION
## Added

* **Open Image in Album** context menu entry. This is useful to open an image in album/time-based context from e.g. a search or map view.
    ![screenshot](https://github.com/user-attachments/assets/3b2acc97-8766-412a-b456-5b6502b1a87b)
* **Scroll persistence**: the scrollable views (album, timeline, highlights, flex) now persist the scroll position via a file-based anchor in the URL (`f` parameter). Refreshing or sharing the URL within a long album should therefore retain the viewed position. This supports the "Open Image in Album" feature by scrolling it into view on page load.

## Fixed

* There is some functionality that scrolls the view to the top when you change the search query, so that you aren't looking at the new results half-way down the page. This scroll reset seemed to be happening a little too often at weird times, so the fix hopefully only makes it reset the scroll exactly for this scenario and no other.

Note that the scroll on load is still a little glitchy, so if it doesn't work the first time, refreshing should fix it.