### PR TITLE
Add main branch trigger for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
Enable the release workflow to trigger on push events to the main branch.