### PR TITLE
Fix missing data directory on fresh build

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -242,8 +242,13 @@ tasks:
       - task: build
       - task: run
 
+  run:dir:
+    dir: data
+    internal: true
+
   run:
     desc: Run the built API
+    deps: [run:dir]
     cmds:
       - ./photofield
 


### PR DESCRIPTION
Ensure the data directory is created during the build process to prevent issues when trying to build the API for the first time