### PR TITLE
Fix photo changing when opening/closing details view

### DIFF
--- a/.changes/unreleased/Fixed-20250818-203709.yaml
+++ b/.changes/unreleased/Fixed-20250818-203709.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix photo changing when opening/closing details view
+time: 2025-08-18T20:37:09.116894737+02:00

--- a/ui/src/components/CollectionView.vue
+++ b/ui/src/components/CollectionView.vue
@@ -147,10 +147,12 @@ const showDetails = computed(() => {
 const setDetails = (show) => {
   if (show) {
     router.push({
+      query: route.query,
       hash: "#details"
     });
   } else {
     router.replace({
+      query: route.query,
       hash: ""
     });
   }


### PR DESCRIPTION
Preserve query parameters in router navigation to prevent the photo
selection from changing when toggling the details panel.