### PR TITLE
Refactor CI workflow: remove conditional platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,13 +210,7 @@ jobs:
       - name: Test built binary
         run: ./photofield -version
 
-      - name: Build & package for reduced set of platforms
-        if: github.event_name == 'pull_request'
-        run: |
-          task package BUILD_OS_ARCH=windows/amd64,linux/amd64,linux/arm64,darwin/arm64
-
       - name: Build & package all platforms
-        if: github.event_name == 'push'
         run: |
           task package
 


### PR DESCRIPTION
Simplify package step to always build all platforms instead of having
different behavior for PRs vs pushes. This ensures consistent builds
across all CI runs.