### PR TITLE
Fix docker runtime issue with missing file error

### DIFF
--- a/Dockerfile-multiarch
+++ b/Dockerfile-multiarch
@@ -3,7 +3,8 @@ RUN apk add --no-cache \
     exiftool \
     ffmpeg \
     libjpeg-turbo-utils \
-    libwebp && \
+    libwebp \
+    gcompat && \
     ln -s /usr/lib/libwebp.so.7 /usr/lib/libwebp.so
 
 ARG TARGETOS


### PR DESCRIPTION
Resolve the "no such file or directory" error while running the latest Docker container.

The added `gcompat` package is necessary to link against the installed libwebp as the binary is built using the glibc linker and not the musl libc.