### PR TITLE
Fix scrollbar dates

### DIFF
--- a/.changes/unreleased/Fixed-20260120-195404.yaml
+++ b/.changes/unreleased/Fixed-20260120-195404.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix scrollbar dates before 1970 or after 2038 and their timezone handling
+time: 2026-01-20T19:54:04.863264098+01:00

--- a/api.yaml
+++ b/api.yaml
@@ -326,9 +326,10 @@ paths:
                 type: string
                 format: binary
                 description: |
-                  List of `height` uint32-encoded "local" timestamps of photos
+                  List of `height` int32-encoded "local" timestamps of photos
                   in the layout. This is similar to a Unix timestamp, except
-                  that it is offset by the local time zone of the photo.
+                  that it is offset by the local time zone of the photo and
+                  defined as minutes (instead of seconds) since 1970.
 
 
   /scenes/{scene_id}/regions:

--- a/e2e/src/fixtures.ts
+++ b/e2e/src/fixtures.ts
@@ -159,21 +159,26 @@ export class App {
       gps?: boolean;
       gpsClumps?: number;
       gpsSpreadKm?: number;
+      dateYears?: number[];
     }
   ): Promise<void> {
     // Use global cache to generate test data only once per run
     const widthKey = widths.join('_');
     const heightKey = heights.join('_');
     const gpsKey = options?.gps ? `-gps-${options.gpsClumps || 5}-${options.gpsSpreadKm || 2.0}` : '';
+    const dateKey = options?.dateYears ? `-dates-${options.dateYears.join('_')}` : '';
+    // Use dateKey in hash for uniqueness but not in the cache key name
+    const hashInput = `e2e-test-${count}-${widthKey}-${heightKey}-${seed}${gpsKey}${dateKey}`;
     const cacheKey = `e2e-test-${count}-${widthKey}-${heightKey}-${seed}${gpsKey}`;
 
     console.log("Using generated photos cache key:", cacheKey);
     
-    const cache = await globalCache.get(cacheKey, async () => {
+    const cache = await globalCache.get(hashInput, async () => {
       const gpsInfo = options?.gps 
         ? ` with GPS (${options.gpsClumps || 5} clumps, ${options.gpsSpreadKm || 2.0}km spread)` 
         : '';
-      console.log(`Generating ${count} test ${widths.join(',')} x ${heights.join(',')} photos with seed ${seed}${gpsInfo}...`);
+      const dateInfo = options?.dateYears ? ` with dates (${options.dateYears.join(',')})` : '';
+      console.log(`Generating ${count} test ${widths.join(',')} x ${heights.join(',')} photos with seed ${seed}${gpsInfo}${dateInfo}...`);
       
       const exe = process.platform === 'win32' ? '.exe' : '';
       const command = join(process.cwd(), '..', 'photofield' + exe);
@@ -200,6 +205,10 @@ export class App {
         if (options.gpsSpreadKm !== undefined) {
           args.push('-gen-photos.gps-spread-km', options.gpsSpreadKm.toString());
         }
+      }
+      
+      if (options?.dateYears && options.dateYears.length > 0) {
+        args.push('-gen-photos.date-years', options.dateYears.join(','));
       }
       
       console.log("Generating photos:", command, args);

--- a/e2e/src/steps.ts
+++ b/e2e/src/steps.ts
@@ -35,6 +35,18 @@ Given('{int} generated {int} x {int} geo test photos', async ({ app }, count: nu
   });
 });
 
+Given('{int} generated {int} x {int} test photos with dates from {string}', async ({ app }, count: number, width: number, height: number, years: string) => {
+  if (!app.cwd) {
+    await app.useTempDir();
+    console.log("CWD:", app.cwd);
+  }
+  // Parse years string like "1950,1960,1970,2000,2010,2020,2030"
+  const dateYears = years.split(',').map(y => parseInt(y.trim(), 10));
+  await app.generatePhotos(count, 12345, [width], [height], {
+    dateYears: dateYears,
+  });
+});
+
 Given('the config {string}', async ({ app }, p: string) => {
   const configPath = path.resolve(__dirname, "..", "configs", p);
   await fs.copyFile(configPath, app.path("configuration.yaml"));

--- a/e2e/tests/timeline-dates.feature
+++ b/e2e/tests/timeline-dates.feature
@@ -1,0 +1,25 @@
+Feature: Timeline with Historical Dates
+
+  Background:
+    Given 80 generated 300 x 200 test photos with dates from "1,100,1000,1500,1800,1900,1950,1969,1970,1971,1990,2000,2020,2030,2040,2100,2500"
+    And a running app
+    And the user opens the collection
+
+  Scenario: Timeline loads with photos from different decades
+    Then the page loads
+    And the page shows "100"
+    And the page shows "1000"
+    And the page shows "1500"
+    And the page shows "1800"
+    And the page shows "1900"
+    And the page shows "1950"
+    And the page shows "1969"
+    And the page shows "1970"
+    And the page shows "1971"
+    And the page shows "1990"
+    And the page shows "2000"
+    And the page shows "2020"
+    And the page shows "2030"
+    And the page shows "2040"
+    And the page shows "2100"
+    And the page shows "2500"

--- a/internal/render/scene.go
+++ b/internal/render/scene.go
@@ -260,10 +260,10 @@ func (scene *Scene) Draw(ctx context.Context, config *Render, c *canvas.Context,
 // better range of years within int32 (2115 BC - 6055 AD instead of 1901 - 2038).
 //
 // For a given height, it maps each row (y-coordinate) to the timestamp of the photo that
-// occupies that row in the scene layout. The timestamps are adjusted to UTC by adding
-// the timezone offset. If a photo has no valid DateTime, the previous photo's timestamp
-// is reused. The height parameter specifies the output resolution, and source provides
-// access to photo metadata.
+// occupies that row in the scene layout. The timestamps represent local photo time,
+// converted from UTC by adding the timezone offset. If a photo has no valid DateTime,
+// the previous photo's timestamp is reused. The height parameter specifies the output
+// resolution, and source provides access to photo metadata.
 func (scene *Scene) GetTimestamps(height int, source *image.Source) []int32 {
 	scale := float64(height) / scene.Bounds.H
 	timestamps := make([]int32, height)

--- a/internal/render/scene.go
+++ b/internal/render/scene.go
@@ -255,13 +255,22 @@ func (scene *Scene) Draw(ctx context.Context, config *Render, c *canvas.Context,
 
 }
 
-func (scene *Scene) GetTimestamps(height int, source *image.Source) []uint32 {
+// GetTimestamps generates a slice of Unix-like timestamps for each row in the
+// rendered scene. The timestamp is defined in minutes instead of seconds for
+// better range of years within int32 (2115 BC - 6055 AD instead of 1901 - 2038).
+//
+// For a given height, it maps each row (y-coordinate) to the timestamp of the photo that
+// occupies that row in the scene layout. The timestamps are adjusted to UTC by adding
+// the timezone offset. If a photo has no valid DateTime, the previous photo's timestamp
+// is reused. The height parameter specifies the output resolution, and source provides
+// access to photo metadata.
+func (scene *Scene) GetTimestamps(height int, source *image.Source) []int32 {
 	scale := float64(height) / scene.Bounds.H
-	timestamps := make([]uint32, height)
+	timestamps := make([]int32, height)
 
 	i := 0
 	ty := -1.
-	t := uint32(0)
+	t := int32(0)
 	var photo Photo
 	for y := 0; y < height; y++ {
 		frac := (float64(y) + 0.5) / float64(height)
@@ -276,7 +285,7 @@ func (scene *Scene) GetTimestamps(height int, source *image.Source) []uint32 {
 		info := photo.GetInfo(source)
 		if !info.DateTime.IsZero() {
 			_, timezoneOffsetSeconds := info.DateTime.Zone()
-			t = uint32(info.DateTime.Unix() + int64(timezoneOffsetSeconds))
+			t = int32((info.DateTime.Unix() + int64(timezoneOffsetSeconds)) / 60)
 		}
 		timestamps[y] = t
 	}

--- a/internal/test/photogen.go
+++ b/internal/test/photogen.go
@@ -460,7 +460,7 @@ func (g *TestImageGenerator) setExifTags(images []GeneratedImage) error {
 
 		cmd := exec.Command("exiftool", args...)
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to set EXIF tags for %s: %w", img.Name, err)
+			return fmt.Errorf("failed to set EXIF tags for %s: %s: %w", img.Name, strings.Join(args, " "), err)
 		}
 	}
 

--- a/ui/src/components/Scrollbar.vue
+++ b/ui/src/components/Scrollbar.vue
@@ -66,7 +66,7 @@ const props = defineProps({
     required: true
   },
   timestamps: {
-    type: Uint32Array,
+    type: Int32Array,
   },
 });
 
@@ -113,15 +113,9 @@ watchDebounced(timestamps, () => {
   isRecentChange.value = false
 }, { debounce: 2000 });
 
-function timezoneOffsetNow() {
-  const date = new Date();
-  return date.getTimezoneOffset() * 60;
-}
-
 const marker = computed(() => {
   if (!timestamps.value) return { level: 0, markers: [] };
 
-  const offset = timezoneOffsetNow();
   const date = new Date();
   const ts = timestamps.value;
 
@@ -140,7 +134,7 @@ const marker = computed(() => {
 
   for (let i = 0; i < maxY; i++) {
     const t = ts[i];
-    date.setTime(t * 1000 + offset);
+    date.setTime(t * 60000);
     const yr = date.getFullYear();
     const mo = date.getMonth();
     const dy = date.getDate();
@@ -198,7 +192,6 @@ const thumbTopPx = computed(() => {
 const thumbLabel = computed(() => {
   if (!timestamps.value?.length) return "";
   if (!marker.value) return "";
-  const offset = timezoneOffsetNow();
   const ratio =
     isHovering.value && !isDragging.value ?
       hoverY.value / containerSize.height.value :
@@ -206,7 +199,7 @@ const thumbLabel = computed(() => {
   if (isNaN(ratio)) return "";
   const index = Math.max(0, Math.min(timestamps.value.length - 1, Math.round(ratio * timestamps.value.length)));
   const t = timestamps.value[index];
-  const date = new Date(t * 1000 + offset);
+  const date = new Date(t * 60000);
   if (isNaN(Number(date))) return "";
   let level = marker.value.level;
   const precise = preciseAnchor.value !== null;

--- a/ui/src/components/Scrollbar.vue
+++ b/ui/src/components/Scrollbar.vue
@@ -122,11 +122,16 @@ const marker = computed(() => {
   let year = -1;
   let month = -1;
   let day = -1;
-  let level = 3; // 3: days, 2: months, 1: years
+  let hour = -1;
+  let level = 4; // 4: hours, 3: days, 2: months, 1: years
+
+  const maxCount = 3;
+  let count = 0;
 
   const years = [];
   const months = [];
   const days = [];
+  const hours = [];
 
   const minDist = 20;
   const maxDist = 100;
@@ -135,13 +140,18 @@ const marker = computed(() => {
   for (let i = 0; i < maxY; i++) {
     const t = ts[i];
     date.setTime(t * 60000);
-    const yr = date.getFullYear();
-    const mo = date.getMonth();
-    const dy = date.getDate();
+    const yr = date.getUTCFullYear();
+    const mo = date.getUTCMonth();
+    const dy = date.getUTCDate();
+    const hr = date.getUTCHours();
 
     if (yr !== year && level >= 1) {
       if (year !== -1 && level > 1) {
-        level = 1;
+        count++;
+        if (count >= maxCount) {
+          count = 0;
+          level = 1;
+        }
       }
       const minY = years.length > 0 ? years[years.length - 1].y + minDist : 0;
       if (minY > maxY) continue;
@@ -150,7 +160,11 @@ const marker = computed(() => {
     }
     if (mo !== month && level >= 2) {
       if (month !== -1 && level > 2) {
-        level = 2;
+        count++;
+        if (count >= maxCount) {
+          count = 0;
+          level = 2;
+        }
       }
       const minY = months.length > 0 ? months[months.length - 1].y + minDist : 0;
       if (minY > maxY) continue;
@@ -158,10 +172,23 @@ const marker = computed(() => {
       month = mo;
     }
     if (dy !== day && level >= 3) {
+      if (day !== -1 && level > 3) {
+        count++;
+        if (count >= maxCount) {
+          count = 0;
+          level = 3;
+        }
+      }
       const minY = days.length > 0 ? days[days.length - 1].y + minDist : 0;
       if (minY > maxY) continue;
       if (minY - i < maxDist) days.push({ y: Math.max(minY, i), t, label: dateFormat(date, "d MMM") });
       day = dy;
+    }
+    if (hr !== hour && level >= 4) {
+      const minY = hours.length > 0 ? hours[hours.length - 1].y + minDist : 0;
+      if (minY > maxY) continue;
+      if (minY - i < maxDist) hours.push({ y: Math.max(minY, i), t, label: dateFormat(date, "HH:")+"00" });
+      hour = hr;
     }
   }
 
@@ -172,6 +199,8 @@ const marker = computed(() => {
       return { level, items: months };
     case 3:
       return { level, items: days };
+    case 4:
+      return { level, items: hours };
   }
   return { level, items: [] };
 });
@@ -201,18 +230,19 @@ const thumbLabel = computed(() => {
   const t = timestamps.value[index];
   const date = new Date(t * 60000);
   if (isNaN(Number(date))) return "";
+
   let level = marker.value.level;
   const precise = preciseAnchor.value !== null;
   if (precise) level++;
   switch (level) {
     case 1:
-      return dateFormat(date, "MMM yyyy");
+      return dateFormat(date, "d MMM yyyy");
     case 2:
-      return dateFormat(date, "d MMM");
+      return dateFormat(date, "d MMM yyyy");
     case 3:
-      return dateFormat(date, "EEE HH:mm");
+      return dateFormat(date, "d MMM HH:mm");
     case 4:
-      return dateFormat(date, "HH:mm:ss");
+      return dateFormat(date, "HH:mm");
   }
   return "";
 });

--- a/ui/src/use.js
+++ b/ui/src/use.js
@@ -486,7 +486,7 @@ export function useTimestamps({ scene, height }) {
   )
 
   const timestamps = computed(() => {
-    return new Uint32Array(datesBuffer.value);
+    return new Int32Array(datesBuffer.value);
   });
 
   return timestamps;
@@ -504,9 +504,7 @@ export function useTimestampsDate({ timestamps, ratio }) {
         )
       );
     const timestamp = timestamps.value[index];
-    const now = new Date();
-    const offset = now.getTimezoneOffset()*60;
-    const d = new Date((timestamp + offset) * 1000);
+    const d = new Date(timestamp*60000);
     if (isNaN(Number(d))) return null;
     return d;
   })


### PR DESCRIPTION
Fixes #159 

This pull request introduces comprehensive improvements to how photo timeline dates are handled, especially for years outside the typical Unix timestamp range (before 1970 and after 2038), and enhances test coverage for historical and future dates. The changes include a new timestamp encoding (minutes since 1970, as int32), fixes to time zone handling, updates to the API and UI, and new end-to-end tests for photos spanning a wide range of years.

**Date and timestamp handling improvements:**

* Changed the encoding of photo timestamps from uint32 seconds to int32 minutes since 1970, greatly expanding the supported date range and preventing overflow for dates before 1970 or after 2038. Updated all related API documentation and implementation. [[1]](diffhunk://#diff-f1cb3b3ecb32bb4cd8b5cb7a4f7cc5217afb2b62468af3db51b4cc9be379d671L329-R332) [[2]](diffhunk://#diff-bfcbebc95d2efe9c6e7320a061d22643822cead7557718077fe92d8458dcbf4bL258-R273) [[3]](diffhunk://#diff-bfcbebc95d2efe9c6e7320a061d22643822cead7557718077fe92d8458dcbf4bL279-R288) [[4]](diffhunk://#diff-3ef2cb57ca2b38e211474a04c927805daca70d6f6da5bf327f3d1c7b62317c36L489-R489)
* Fixed timezone handling in the scrollbar and timeline UI by switching to UTC-based calculations, ensuring accurate display of historical and future dates. [[1]](diffhunk://#diff-6f1b34fdc60d48cadc8c87e499c8185455a79b24abe83ec48f856279830cc361L116-R192) [[2]](diffhunk://#diff-6f1b34fdc60d48cadc8c87e499c8185455a79b24abe83ec48f856279830cc361L201-R245) [[3]](diffhunk://#diff-3ef2cb57ca2b38e211474a04c927805daca70d6f6da5bf327f3d1c7b62317c36L507-R507)

**Testing and test data generation:**

* Added support for generating test photos with EXIF dates distributed across arbitrary years, including years before 1970 and after 2038. This is controlled via a new `-gen-photos.date-years` option and is integrated into the test photo generator and CLI. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L1833-R1833) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R1845-R1854) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R1873-R1884) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R2056) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L2051-R2074) [[6]](diffhunk://#diff-05d7359b46f5233fa81b5420e0730ab45d46e2c475f6f39bb32b0dc40f30051dR162-R181) [[7]](diffhunk://#diff-05d7359b46f5233fa81b5420e0730ab45d46e2c475f6f39bb32b0dc40f30051dR210-R213) [[8]](diffhunk://#diff-46144312e9b09975a39ac50459813041bcccf10447c0731335978b12f3026961R38-R49)

**End-to-end and feature testing:**

* Introduced a new end-to-end test scenario for the timeline with photos from a wide range of years, verifying correct rendering and labeling of years in the UI.

**UI and component updates:**

* Updated the `Scrollbar.vue` component and its dependencies to work with the new timestamp format, and improved the logic for date markers and labels to support a broader range of dates and higher precision (hours, days, months, years). [[1]](diffhunk://#diff-6f1b34fdc60d48cadc8c87e499c8185455a79b24abe83ec48f856279830cc361L69-R69) [[2]](diffhunk://#diff-6f1b34fdc60d48cadc8c87e499c8185455a79b24abe83ec48f856279830cc361L116-R192) [[3]](diffhunk://#diff-6f1b34fdc60d48cadc8c87e499c8185455a79b24abe83ec48f856279830cc361R202-R203) [[4]](diffhunk://#diff-6f1b34fdc60d48cadc8c87e499c8185455a79b24abe83ec48f856279830cc361L201-R245)

**Bug fixes:**

* Fixed a bug in the EXIF tag setter to improve error reporting when setting EXIF tags fails during test photo generation.
* Added a changelog entry summarizing the fix for scrollbar date and timezone handling.