### PR TITLE
ci: prevent duplicate builds on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build:
-    # Skip builds on main branch if this commit has a tag
+    # Skip main branch push events for release commits since they will be built when the tag is pushed
     if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/') || !startsWith(github.event.head_commit.message, 'Release v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v*'
   pull_request:
     types: [opened, synchronize]
 
@@ -21,6 +21,8 @@ permissions:
 
 jobs:
   build:
+    # Skip builds on main branch if this commit has a tag
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/') || !startsWith(github.event.head_commit.message, 'Release v')
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Skip CI builds on main branch for release commits since they will be built when the tag is pushed.

This prevents double builds when running `task release:push` which pushes both the commit and the tag.

## Changes
- Changed tag pattern from `*` to `v*` for more specific matching
- Added conditional to build job to skip main branch builds for release commits
- Release commits are identified by commit messages starting with "Release v"

## Result
When running `task release:push`:
- ✅ Tag push triggers full CI pipeline
- ❌ Main branch push is skipped (since commit will be built via tag)
- ✅ Regular commits to main still trigger CI
- ✅ Pull requests still trigger CI