### PR TITLE
Add support for HEIC/HEIF, GIF, and MOV formats with FFmpeg integration

### DIFF
--- a/.changes/unreleased/heic-support.md
+++ b/.changes/unreleased/heic-support.md
@@ -1,0 +1,7 @@
+---
+kind: Added
+body: Add HEIC/HEIF, GIF image and MOV video format support via FFmpeg
+time: 2026-01-25T21:00:00Z
+---
+
+HEIC (High Efficiency Image Container), HEIF (High Efficiency Image Format), GIF, and MOV (QuickTime) files are now fully supported. These formats, commonly used by iOS devices and other platforms, are decoded using FFmpeg when available. The extensions `.heic`, `.heif`, `.gif`, and `.mov` are now included in the default configuration, so Photofield will automatically index and display these files alongside your other media.

--- a/.changes/unreleased/heic-support.md
+++ b/.changes/unreleased/heic-support.md
@@ -4,4 +4,4 @@ body: Add HEIC/HEIF, GIF image and MOV video format support via FFmpeg
 time: 2026-01-25T21:00:00Z
 ---
 
-HEIC (High Efficiency Image Container), HEIF (High Efficiency Image Format), GIF, and MOV (QuickTime) files are now fully supported. These formats, commonly used by iOS devices and other platforms, are decoded using FFmpeg when available. The extensions `.heic`, `.heif`, `.gif`, and `.mov` are now included in the default configuration, so Photofield will automatically index and display these files alongside your other media.
+HEIC (High Efficiency Image Container), HEIF (High Efficiency Image Format), GIF, and MOV (QuickTime) files are now supported when FFmpeg is available. These formats, commonly used by iOS devices and other platforms, are decoded using FFmpeg. The extensions `.heic`, `.heif`, `.gif`, and `.mov` are now included in the default configuration, so Photofield will automatically index and display these files alongside your other media when FFmpeg is installed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,13 @@ RUN \
     -o /build/photofield .
 
 # Runtime stage
-FROM alpine:3.22
+FROM alpine:3.23
 
+# Install runtime dependencies
+# - exiftool: metadata extraction
+# - ffmpeg: video thumbnails, HEIC/HEIF/MOV/GIF support (8.0.1+ includes HEVC decoder)
+# - libjpeg-turbo-utils: fast JPEG decoding via djpeg
+# - libwebp: WebP encoding support
 RUN apk add --no-cache exiftool ffmpeg libjpeg-turbo-utils libwebp && \
     ln -s /usr/lib/libwebp.so.7 /usr/lib/libwebp.so
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM alpine:3.23
 
 # Install runtime dependencies
 # - exiftool: metadata extraction
-# - ffmpeg: video thumbnails, HEIC/HEIF/MOV/GIF support (8.0.1+ includes HEVC decoder)
+# - ffmpeg: video thumbnails, HEIC/HEIF/MOV/GIF support (requires build with HEVC/H.265 decoder + libheif; v7.0+ recommended, see docs)
 # - libjpeg-turbo-utils: fast JPEG decoding via djpeg
 # - libwebp: WebP encoding support
 RUN apk add --no-cache exiftool ffmpeg libjpeg-turbo-utils libwebp && \

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -127,8 +127,8 @@ media:
     
   # File extensions to index on the file system
   extensions: [
-    ".jpg", ".jpeg", ".png", ".avif", ".bmp", ".pam", ".ppm", ".jxl", ".exr", ".cr2", ".dng",
-    ".mp4",
+    ".jpg", ".jpeg", ".png", ".avif", ".bmp", ".pam", ".ppm", ".jxl", ".exr", ".cr2", ".dng", ".heic", ".heif", ".gif",
+    ".mp4", ".mov",
   ]
 
   # Used to extract dates from file names as a heuristic in case of missing or
@@ -137,11 +137,10 @@ media:
   date_formats: ["20060201_150405"]
   images:
     # Extensions to use to understand a file to be an image
-    # extensions: [".jpg", ".jpeg", ".png", ".gif"]
-    extensions: [".jpg", ".jpeg", ".png", ".avif", ".bmp", ".pam", ".ppm", ".jxl", ".exr", ".cr2", ".dng"]
+    extensions: [".jpg", ".jpeg", ".png", ".avif", ".bmp", ".pam", ".ppm", ".jxl", ".exr", ".cr2", ".dng", ".heic", ".heif", ".gif"]
 
   videos:
-    extensions: [".mp4"]
+    extensions: [".mp4", ".mov"]
 
   # 
   # Media source configuration

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -3,7 +3,7 @@
 These tools are not strictly required, but if they are installed in your system, Photofield will use them to improve performance, metadata extraction, thumbnail generation, and video previews.
 
 - [ExifTool]: Extracts metadata from many more formats than the embedded [goexif].
-- [FFmpeg]: Generates video thumbnails and previews and adds support for more image formats (even basic RAW).
+- [FFmpeg]: Generates video thumbnails and previews and adds support for more image formats including HEIC/HEIF (iOS photos), MOV (QuickTime videos), and basic RAW formats. **(v7.0+ recommended)**
 - [djpeg (libjpeg-turbo)]: Accelerates JPEG decoding of big images in cases where there are no other appropriate thumbnails available.
 - [libwebp]: Enables high-performance WebP encoding via dynamic library loading. When available, the [go-libwebp] encoder can use the native libwebp dynamic shared library for faster encoding (`webp-jackdyn`) compared to pure Go implementations (`webp-jacktra`).
 

--- a/main.go
+++ b/main.go
@@ -2292,6 +2292,10 @@ func main() {
 		mime.AddExtensionType(".png", "image/png")
 		mime.AddExtensionType(".jpg", "image/jpg")
 		mime.AddExtensionType(".jpeg", "image/jpeg")
+		mime.AddExtensionType(".heic", "image/heic")
+		mime.AddExtensionType(".heif", "image/heif")
+		mime.AddExtensionType(".gif", "image/gif")
+		mime.AddExtensionType(".mov", "video/quicktime")
 		mime.AddExtensionType(".ico", "image/vnd.microsoft.icon")
 
 		uifs, err := fs.Sub(StaticFs, "ui/dist")

--- a/main.go
+++ b/main.go
@@ -2281,22 +2281,25 @@ func main() {
 	r.Mount("/debug", middleware.Profiler())
 	r.Handle("/debug/fgprof", fgprof.Handler())
 
+	// Register media MIME types for both UI+API and API-only modes
+	// (needed for /files/{id} endpoint in all modes)
+	mime.AddExtensionType(".png", "image/png")
+	mime.AddExtensionType(".jpg", "image/jpg")
+	mime.AddExtensionType(".jpeg", "image/jpeg")
+	mime.AddExtensionType(".heic", "image/heic")
+	mime.AddExtensionType(".heif", "image/heif")
+	mime.AddExtensionType(".gif", "image/gif")
+	mime.AddExtensionType(".mov", "video/quicktime")
+	mime.AddExtensionType(".ico", "image/vnd.microsoft.icon")
+
 	msg := ""
 	if apiPrefix != "/" {
-		// Hardcode well-known mime types, see https://github.com/golang/go/issues/32350
+		// Hardcode well-known mime types for UI assets, see https://github.com/golang/go/issues/32350
 		mime.AddExtensionType(".js", "text/javascript")
 		mime.AddExtensionType(".css", "text/css")
 		mime.AddExtensionType(".html", "text/html")
 		mime.AddExtensionType(".woff", "font/woff")
 		mime.AddExtensionType(".woff2", "font/woff2")
-		mime.AddExtensionType(".png", "image/png")
-		mime.AddExtensionType(".jpg", "image/jpg")
-		mime.AddExtensionType(".jpeg", "image/jpeg")
-		mime.AddExtensionType(".heic", "image/heic")
-		mime.AddExtensionType(".heif", "image/heif")
-		mime.AddExtensionType(".gif", "image/gif")
-		mime.AddExtensionType(".mov", "video/quicktime")
-		mime.AddExtensionType(".ico", "image/vnd.microsoft.icon")
 
 		uifs, err := fs.Sub(StaticFs, "ui/dist")
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -2281,25 +2281,22 @@ func main() {
 	r.Mount("/debug", middleware.Profiler())
 	r.Handle("/debug/fgprof", fgprof.Handler())
 
-	// Register media MIME types for both UI+API and API-only modes
-	// (needed for /files/{id} endpoint in all modes)
-	mime.AddExtensionType(".png", "image/png")
-	mime.AddExtensionType(".jpg", "image/jpg")
-	mime.AddExtensionType(".jpeg", "image/jpeg")
-	mime.AddExtensionType(".heic", "image/heic")
-	mime.AddExtensionType(".heif", "image/heif")
-	mime.AddExtensionType(".gif", "image/gif")
-	mime.AddExtensionType(".mov", "video/quicktime")
-	mime.AddExtensionType(".ico", "image/vnd.microsoft.icon")
-
 	msg := ""
 	if apiPrefix != "/" {
-		// Hardcode well-known mime types for UI assets, see https://github.com/golang/go/issues/32350
+		// Hardcode well-known mime types, see https://github.com/golang/go/issues/32350
 		mime.AddExtensionType(".js", "text/javascript")
 		mime.AddExtensionType(".css", "text/css")
 		mime.AddExtensionType(".html", "text/html")
 		mime.AddExtensionType(".woff", "font/woff")
 		mime.AddExtensionType(".woff2", "font/woff2")
+		mime.AddExtensionType(".png", "image/png")
+		mime.AddExtensionType(".jpg", "image/jpg")
+		mime.AddExtensionType(".jpeg", "image/jpeg")
+		mime.AddExtensionType(".heic", "image/heic")
+		mime.AddExtensionType(".heif", "image/heif")
+		mime.AddExtensionType(".gif", "image/gif")
+		mime.AddExtensionType(".mov", "video/quicktime")
+		mime.AddExtensionType(".ico", "image/vnd.microsoft.icon")
 
 		uifs, err := fs.Sub(StaticFs, "ui/dist")
 		if err != nil {


### PR DESCRIPTION
Introduce support for HEIC, HEIF, GIF, and MOV formats, enhancing media compatibility. FFmpeg integration allows for decoding these formats, which are commonly used on iOS devices. The default configuration now includes these extensions for automatic indexing and display in Photofield.

Contributes to #52 