### PR TITLE
Fix HEIC thumbnail generation in FFmpeg

### DIFF
--- a/internal/io/ffmpeg/ffmpeg.go
+++ b/internal/io/ffmpeg/ffmpeg.go
@@ -137,7 +137,7 @@ func (f FFmpeg) Get(ctx context.Context, id io.ImageId, path string) io.Result {
 		"-loglevel", "error",
 		"-i", path,
 		"-vframes", "1",
-		"-vf", f.FilterGraph(),
+		"-filter_complex", f.FilterGraph(),
 		// "-q:v", "2",
 		// "-f", "image2pipe", // jpeg
 		"-c:v", "pam",


### PR DESCRIPTION
Update the FFmpeg command to use `-filter_complex` instead of `-vf` for generating thumbnails from HEIC files, resolving the issue with incorrect transcoding.