### PR TITLE
fix: use Alpine 3.24 to get ffmpeg 8.1.2 for correct HEIC transcoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN \
     -o /build/photofield .
 
 # Runtime stage
-FROM alpine:3.23
+# Alpine 3.24 ships ffmpeg 8.1.2 which fixes HEIC tile assembly + orientation handling
+FROM alpine:3.24
 
 # Install runtime dependencies
 # - exiftool: metadata extraction


### PR DESCRIPTION
## Problem

The Docker build produces corrupted/wrong thumbnails for HEIC files, showing blank/white areas instead of the actual image content.

## Root Cause

Alpine 3.23 ships **ffmpeg 8.0.1** which has a bug in HEIC tile assembly and orientation handling. When generating thumbnails from HEIC files:

- Only the first tile is output (2016×1512) instead of assembling all tiles
- The tile is incorrectly rotated 90° during scaling
- Produces a portrait image (183×256) instead of the correct landscape (256×192)

## Fix

Upgrade to **Alpine 3.24** which ships **ffmpeg 8.1.2** — this fix resolves the HEIC tile assembly and orientation issues.

## Verification

```bash
# Alpine 3.23 (broken):
ffmpeg -i IMG_3880.HEIC -vframes 1 -filter_complex "scale=..." -c:v pam ...
# → WIDTH 183, HEIGHT 256 (rotated, wrong)

# Alpine 3.24 (fixed):
# → WIDTH 256, HEIGHT 192 (correct)
```